### PR TITLE
:arrow_up: Bump upper bound of caikit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit>=0.2.0,<0.3.0", # Core abstractions
+    "caikit>=0.2.0,<0.4.0", # Core abstractions
     "grpcio>=1.35.0,<2.0", # Client calls to TGIS
     "requests>=2.28.2,<3", # Health check calls to TGIS
 ]


### PR DESCRIPTION
`caikit-tgis-backend` itself does not have dataobjects affected by the latest [0.3.0 caikit release](https://github.com/caikit/caikit/releases/tag/v0.3.0). Here we bump uthe pper bound of caikit to allow any consumers of `caikit-tgis-backend` to use the latest caikit release