### PR TITLE
✨ Implement auto-recovery of the managed TGIS subprocess

### DIFF
--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -65,12 +65,17 @@ class ManagedTGISSubprocess:
         """Create a ManagedTGISSubprocess
 
         Args:
-            model_path (str): path to model files on disk to be loaded by TGIS
-            grpc_port (int, optional): port TGIS will listen on for gRPC requests. Defaults to 50055.
-            http_port (int, optional): port TGIS will listen on for HTTP requests. Defaults to 3000.
-            health_poll_timeout (float, optional): number of seconds to wait for a health check request. Defaults to 1.
-            bootup_poll_delay (float, optional): number of seconds between health checks during bootup. Defaults to 1.
-            load_timeout (float, optional): number of seconds to wait for TGIS to boot before cancelling. Defaults to 30.
+            model_path (str): path to model files on disk to be loaded by TGIS.
+            grpc_port (int, optional): port TGIS will listen on for gRPC requests.
+                Defaults to 50055.
+            http_port (int, optional): port TGIS will listen on for HTTP requests.
+                Defaults to 3000.
+            health_poll_timeout (float, optional): number of seconds to wait for a
+                health check request. Defaults to 1.
+            bootup_poll_delay (float, optional): number of seconds between health
+                checks during bootup. Defaults to 1.
+            load_timeout (float, optional): number of seconds to wait for TGIS to
+                boot before cancelling. Defaults to 30.
         """
         # parameters of the TGIS subprocess
         self._model_path = model_path
@@ -124,7 +129,8 @@ class ManagedTGISSubprocess:
             timeout (float, optional): maximum duration to wait for. Defaults to the load_timeout.
 
         Raises:
-            Exception: If TGIS is detected to be down, the exception that caused the most recent TGIS restart
+            Exception: If TGIS is detected to be down, the exception that caused
+                the most recent TGIS restart
             TimeoutError: If the timeout is reached
         """
         if timeout is None:

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -218,23 +218,20 @@ class ManagedTGISSubprocess:
 
             # check if the process stopped/crashed
             with self._mutex:
-                try:
-                    if self._tgis_proc.poll() is not None:
-                        if self._tgis_state != _TGISState.STOPPED:
-                            self._ensure_terminated()
-                        exc = RuntimeError(
-                            "TGIS failed to boot up with the model. See logs for details"
-                        )
-                        self._bootup_exc = exc
-                        error("<MTS11752287E>", exc)
-                except AttributeError:
-                    if self._tgis_state != _TGISState.STOPPED:
-                        self._ensure_terminated()
+                if self._tgis_proc is None:
                     exc = RuntimeError(
                         "TGIS process terminated while waiting for it to boot with the model"
                     )
                     self._bootup_exc = exc
                     error("<MTS26557152E>", exc)
+
+                if self._tgis_proc.poll() is not None:
+                    self._ensure_terminated()
+                    exc = RuntimeError(
+                        "TGIS failed to boot up with the model. See logs for details"
+                    )
+                    self._bootup_exc = exc
+                    error("<MTS11752287E>", exc)
 
             # see if we can get a passing health check request
             try:

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -250,7 +250,9 @@ class ManagedTGISSubprocess:
             except requests.exceptions.RequestException as e:
                 # Ignore ConnectionErrors that are expected during boot up
                 if isinstance(e, requests.exceptions.ConnectionError):
+                    log.debug2("Ignoring ConnectionError from _health_check")
                     continue
+
                 log.warning(
                     "<MTS96271549W>",
                     "TGIS health check failed in _monitor_bootup: %s",
@@ -277,6 +279,9 @@ class ManagedTGISSubprocess:
             log.debug2("_health_check called without subprocess running")
             return False
 
+        log.debug2(
+            "sending health probe request with timeout [%s]", self._health_poll_timeout
+        )
         resp = requests.get(
             f"http://localhost:{self._http_port}/health",
             timeout=self._health_poll_timeout,

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Managed TGIS subprocess with automatic fault recovery
+"""Managed TGIS subprocess with automatic failure recovery
 
 Creates a wrapped gRPC client that knows that the gRPC server is managed as a
+subprocess. When the client observes errors, it can trigger a restart of the
 subprocess.
 """
 
 # Standard
-from datetime import timedelta
 from enum import Enum
 from threading import Lock
+from typing import Optional
 import os
 import shlex
 import subprocess
@@ -42,36 +43,30 @@ from .protobufs import generation_pb2_grpc
 log = alog.use_channel("TGISPROC")
 error = error_handler.get(log)
 
+
 class _TGISState(Enum):
-    UNKNOWN = 0
-    STOPPED = 1 # subprocess does not exist
-    BOOTING = 2 # attempting to load the model
-    READY = 3 # ready for inference requests
+    STOPPED = 0  # subprocess does not exist
+    BOOTING = 1  # attempting to load the model
+    READY = 2  # ready for inference requests
+
 
 # pylint: disable=too-many-instance-attributes
-class ManagedTGISSubprocess():
-    # TODO: consider potential refactor with TGIS connection class for
-    # the many instance attributes
-    def __init__(self,
+class ManagedTGISSubprocess:
+    def __init__(
+        self,
         model_path: str,
         grpc_port: int = 50055,
         http_port: int = 3000,
-        health_poll_timeout: timedelta = None,
-        bootup_poll_delay: timedelta = None,
-        load_timeout: timedelta = None,
+        health_poll_timeout: Optional[float] = None,
+        bootup_poll_delay: Optional[float] = None,
+        load_timeout: Optional[float] = None,
     ):
-        # NOTE: Needs to be set before any possible errors since it's used in
-        #   the destructor
-        self._mutex = Lock()
-        self._tgis_proc = None
-        self._tgis_state: _TGISState = _TGISState.STOPPED
-
-        if not bootup_poll_delay:
-            bootup_poll_delay = timedelta(seconds=1)
-        if not health_poll_timeout:
-            health_poll_timeout = timedelta(seconds=1)
-        if not load_timeout:
-            load_timeout = timedelta(seconds=30)
+        if bootup_poll_delay is None:
+            bootup_poll_delay = 1
+        if health_poll_timeout is None:
+            health_poll_timeout = 1
+        if load_timeout is None:
+            load_timeout = 30
 
         # parameters of the TGIS subprocess
         self._model_path = model_path
@@ -82,9 +77,11 @@ class ManagedTGISSubprocess():
         self._load_timeout = load_timeout
 
         self._hostname = f"localhost:{self._grpc_port}"
-
-        # placeholders
-        self._client = None
+        self._mutex = Lock()
+        self._tgis_state: _TGISState = _TGISState.STOPPED
+        self._tgis_proc = None
+        self._tgis_client = None
+        self._wrapped_client = None
         self._bootup_thread = None
         self._bootup_exc = None
 
@@ -92,18 +89,23 @@ class ManagedTGISSubprocess():
         self.terminate()
 
     def is_ready(self) -> bool:
-        return self._tgis_state == _TGISState.READY and self._client
+        """Return true if a request can be propagated to the subprocess"""
+        return self._tgis_state == _TGISState.READY and self._tgis_client
 
     def get_client(self):
         """Creates a gRPC client to the subprocess
 
         Returns None if the subprocess is not ready and doesn't have an internal client
         """
-        if self._client:
-            # create a wrapped gRPC client stub that defers to self._client
-            return GenerationServiceStubWrapper(self)
+        if self._wrapped_client:
+            return self._wrapped_client
 
-        log.warning("<MTS7717800W>", "get_client called with _client set to None")
+        if self._tgis_client:
+            # create a wrapped gRPC client stub that defers to self._tgis_client
+            self._wrapped_client = GenerationServiceStubWrapper(self)
+            return self._wrapped_client
+
+        log.warning("<MTS7717800W>", "get_client called with _tgis_client set to None")
         return None
 
     def launch(self):
@@ -132,7 +134,7 @@ class ManagedTGISSubprocess():
             if time.time() - start_t >= timeout:
                 return False
 
-            time.sleep(self._bootup_poll_delay.total_seconds())
+            time.sleep(self._bootup_poll_delay)
 
     def terminate(self):
         """Terminate the subprocess, wait for it to exit"""
@@ -153,7 +155,6 @@ class ManagedTGISSubprocess():
             log.debug("_ensure_terminated setting the state to STOPPED")
             self._tgis_state = _TGISState.STOPPED
 
-
     def _launch(self):
         """Launch the subprocess or restart if it exists
 
@@ -165,7 +166,7 @@ class ManagedTGISSubprocess():
         launch_cmd = " ".join(
             [
                 "text-generation-launcher",
-                f"--num-shard 1",
+                "--num-shard 1",
                 f"--model-name {self._model_path}",
                 f"--port {self._http_port}",
             ]
@@ -183,7 +184,6 @@ class ManagedTGISSubprocess():
         self._bootup_thread = threading.Thread(target=self._monitor_bootup, daemon=True)
         self._bootup_thread.start()
 
-
     def _monitor_bootup(self):
         """Ran in a background thread to complete the BOOTING -> READY transition
 
@@ -193,7 +193,7 @@ class ManagedTGISSubprocess():
         # Wait for the server to be ready
         start_t = time.time()
         while True:
-            time.sleep(self._bootup_poll_delay.total_seconds())
+            time.sleep(self._bootup_poll_delay)
 
             # if we are not still booting, exit
             # another thread could have caused a state transition
@@ -237,10 +237,14 @@ class ManagedTGISSubprocess():
                 # Ignore ConnectionErrors that are expected during boot up
                 if isinstance(e, requests.exceptions.ConnectionError):
                     continue
-                log.warning("<MTS96271549W>", "TGIS health check failed in _monitor_bootup: %s", repr(e))
+                log.warning(
+                    "<MTS96271549W>",
+                    "TGIS health check failed in _monitor_bootup: %s",
+                    repr(e),
+                )
 
             # limit how long we wait before giving up
-            if time.time() - start_t >= self._load_timeout.total_seconds():
+            if time.time() - start_t >= self._load_timeout:
                 with self._mutex:
                     # double check that we are still in the booting state
                     if not self._tgis_state == _TGISState.BOOTING:
@@ -261,7 +265,7 @@ class ManagedTGISSubprocess():
 
         resp = requests.get(
             f"http://localhost:{self._http_port}/health",
-            timeout=self._health_poll_timeout.total_seconds(),
+            timeout=self._health_poll_timeout,
         )
         log.debug2("_health_check result [code=%s]", resp.status_code)
 
@@ -270,7 +274,7 @@ class ManagedTGISSubprocess():
     def _create_grpc_client(self):
         log.debug("Connecting to TGIS at [%s] INSECURE", self._hostname)
         channel = grpc.insecure_channel(self._hostname)
-        self._client = generation_pb2_grpc.GenerationServiceStub(channel)
+        self._tgis_client = generation_pb2_grpc.GenerationServiceStub(channel)
 
     def _handle_autorecovery(self):
         """Check if the subprocess might be unhealthy and recover"""
@@ -285,15 +289,17 @@ class ManagedTGISSubprocess():
             if self._health_check():
                 log.debug("Autorecovery skipped because health check is passing")
                 return
-        except:
+        except requests.exceptions.RequestException as e:
+            log.debug("Autorecovery health check failed: %s", repr(e))
             # handle recovery below
-            pass
 
         # restart the process
         with self._mutex:
             # double check that we aren't already booting
             if self._tgis_state == _TGISState.BOOTING:
-                log.debug("Autorecovery (in mutex) skipped because the process is booting")
+                log.debug(
+                    "Autorecovery (in mutex) skipped because the process is booting"
+                )
                 return
 
             log.warning("Autorecovery is restarting TGIS")
@@ -304,46 +310,62 @@ class ManagedTGISSubprocess():
 
 class _MockRPCError(grpc.RpcError):
     """Mocks an RpcError but is generated outside the gRPC code"""
+
     def __init__(self, code):
-        self.code = code
+        self._code = code
 
     def code(self):
-        return self.code
+        return self._code
+
 
 # used to create closures over the subprocess that can be called like a
 # client stub, but have a auto-recovering client to the subprocess
-class _WrappedRPC():
-    def __init__(self, subprocess, rpc_name):
-        self.subprocess = subprocess
+class _WrappedRPC:
+    managed_tgis: ManagedTGISSubprocess
+    rpc_name: str
+
+    def __init__(self, managed_tgis, rpc_name):
+        self.managed_tgis = managed_tgis
         self.rpc_name = rpc_name
 
     def __call__(self, request, context=None):
         # TODO: should wait for the subprocess up until the deadline if booting?
-        if not self.subprocess.is_ready():
+        if not self.managed_tgis.is_ready():
             raise _MockRPCError(grpc.StatusCode.UNAVAILABLE)
 
         try:
             log.debug3("Calling wrapped RPC [%s]", self.rpc_name)
-            return getattr(self.subprocess._client, self.rpc_name).__call__(request, context)
+            return getattr(self.managed_tgis._tgis_client, self.rpc_name).__call__(
+                request, context
+            )
         except grpc.RpcError as rpc_error:
             if rpc_error.code() == grpc.StatusCode.CANCELLED:
                 raise rpc_error
-            elif rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+
+            if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
                 # trigger a check on the process
-                threading.Thread(target=self.subprocess._handle_autorecovery, daemon=True).start()
-                raise rpc_error
-            else:
-                exc_chain = RuntimeError("Unhandled RPC error")
-                exc_chain.__cause__ = rpc_error
-                error("<MTS86992919W>", exc_chain)
+                threading.Thread(
+                    target=self.managed_tgis._handle_autorecovery, daemon=True
+                ).start()
                 raise rpc_error
 
-class GenerationServiceStubWrapper():
-    def __init__(self, subprocess: ManagedTGISSubprocess):
+            exc_chain = RuntimeError("Unhandled RPC error")
+            exc_chain.__cause__ = rpc_error
+            error("<MTS86992919W>", exc_chain)
+            raise rpc_error
+
+
+class GenerationServiceStubWrapper:
+    def __init__(self, managed_tgis: ManagedTGISSubprocess):
         # use the attributes of the Servicer to discover the names of the RPCs
         # the Stub creates its rpcs as attributes in __init__, so we can't use that
-        rpc_names = [func for func in dir(generation_pb2_grpc.GenerationServiceServicer) if callable(getattr(generation_pb2_grpc.GenerationServiceServicer, func)) and not func.startswith("__")]
+        rpc_names = [
+            func
+            for func in dir(generation_pb2_grpc.GenerationServiceServicer)
+            if callable(getattr(generation_pb2_grpc.GenerationServiceServicer, func))
+            and not func.startswith("__")
+        ]
 
-        for rpc in rpc_names:
-            log.debug3("Creating wrapped RPC call for [%s]", rpc)
-            setattr(self, rpc, _WrappedRPC(subprocess, rpc))
+        for rpc_name in rpc_names:
+            log.debug3("Creating wrapped RPC call for [%s]", rpc_name)
+            setattr(self, rpc_name, _WrappedRPC(managed_tgis, rpc_name))

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -61,6 +61,7 @@ class ManagedTGISSubprocess:
         health_poll_timeout: float = 1,
         bootup_poll_delay: float = 1,
         load_timeout: float = 30,
+        num_gpus: int = 1,
     ):
         """Create a ManagedTGISSubprocess
 
@@ -84,6 +85,7 @@ class ManagedTGISSubprocess:
         self._bootup_poll_delay = bootup_poll_delay
         self._health_poll_timeout = health_poll_timeout
         self._load_timeout = load_timeout
+        self._num_gpus = num_gpus
 
         self._hostname = f"localhost:{self._grpc_port}"
         self._mutex = Lock()
@@ -188,7 +190,7 @@ class ManagedTGISSubprocess:
         launch_cmd = " ".join(
             [
                 "text-generation-launcher",
-                "--num-shard 1",
+                f"--num-shard {self._num_gpus}",
                 f"--model-name {self._model_path}",
                 f"--port {self._http_port}",
             ]

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -25,6 +25,7 @@ from threading import Lock
 import os
 import shlex
 import subprocess
+import threading
 import time
 
 # Third Party
@@ -55,8 +56,8 @@ class ManagedTGISSubprocess():
         model_path: str,
         grpc_port: int = 50055,
         http_port: int = 3000,
-        health_poll_delay: timedelta = None,
         health_poll_timeout: timedelta = None,
+        bootup_poll_delay: timedelta = None,
         load_timeout: timedelta = None,
     ):
         # NOTE: Needs to be set before any possible errors since it's used in
@@ -65,8 +66,8 @@ class ManagedTGISSubprocess():
         self._tgis_proc = None
         self._tgis_state: _TGISState = _TGISState.STOPPED
 
-        if not health_poll_delay:
-            health_poll_delay = timedelta(seconds=1)
+        if not bootup_poll_delay:
+            bootup_poll_delay = timedelta(seconds=1)
         if not health_poll_timeout:
             health_poll_timeout = timedelta(seconds=1)
         if not load_timeout:
@@ -76,19 +77,22 @@ class ManagedTGISSubprocess():
         self._model_path = model_path
         self._grpc_port = grpc_port
         self._http_port = http_port
-        self._health_poll_delay = health_poll_delay
+        self._bootup_poll_delay = bootup_poll_delay
         self._health_poll_timeout = health_poll_timeout
         self._load_timeout = load_timeout
 
         self._hostname = f"localhost:{self._grpc_port}"
 
+        # placeholders
         self._client = None
+        self._bootup_thread = None
+        self._bootup_exc = None
 
     def __del__(self):
         self.terminate()
 
     def is_ready(self) -> bool:
-        return self._tgis_state == _TGISState.READY
+        return self._tgis_state == _TGISState.READY and self._client
 
     def get_client(self):
         """Creates a gRPC client to the subprocess
@@ -107,19 +111,55 @@ class ManagedTGISSubprocess():
         with self._mutex:
             self._launch()
 
+    def wait_until_ready(self, timeout=None) -> bool:
+        start_t = time.time()
+
+        # wait for the boot monitoring thread if we have one
+        if self._bootup_thread:
+            self._bootup_thread.join(timeout)
+
+        while True:
+            log.debug("wait_until_ready saw state [%s]", self._tgis_state)
+            if self._tgis_state == _TGISState.READY:
+                return True
+
+            if self._tgis_state == _TGISState.STOPPED:
+                # raise the bootup exception if we captured one
+                if self._bootup_exc:
+                    raise self._bootup_exc
+                return False
+
+            if time.time() - start_t >= timeout:
+                return False
+
+            time.sleep(self._bootup_poll_delay.total_seconds())
+
     def terminate(self):
         """Terminate the subprocess, wait for it to exit"""
         with self._mutex:
             self._ensure_terminated()
 
+    def _ensure_terminated(self):
+        """Terminate the subprocess if it exists
+
+        _mutex should be locked before calling this
+        """
+        if self._tgis_state != _TGISState.STOPPED:
+            if self._tgis_proc:
+                self._tgis_proc.terminate()
+                self._tgis_proc = None
+                # disown the bootup thread (but keep the exception if one was captured)
+                self._bootup_thread = None
+            log.debug("_ensure_terminated setting the state to STOPPED")
+            self._tgis_state = _TGISState.STOPPED
+
+
     def _launch(self):
         """Launch the subprocess or restart if it exists
 
-        _proc_mutex should be locked before calling
+        _mutex should be locked before calling
         """
         self._ensure_terminated()
-
-        log.debug("Launching TGIS subprocess for model [%s]", self._model_path)
 
         # Launch TGIS
         launch_cmd = " ".join(
@@ -130,90 +170,100 @@ class ManagedTGISSubprocess():
                 f"--port {self._http_port}",
             ]
         )
-        log.debug2("TGIS command: [%s]", launch_cmd)
+        log.debug2("Launching TGIS with command: [%s]", launch_cmd)
         env = os.environ.copy()
         env["GRPC_PORT"] = str(self._grpc_port)
         # Long running process
         # pylint: disable=consider-using-with
         self._tgis_proc = subprocess.Popen(shlex.split(launch_cmd), env=env)
+        log.debug("_launch setting state to BOOTING")
         self._tgis_state = _TGISState.BOOTING
-        self._create_grpc_client()
+        # launch background thread to monitor the boot sequence
+        # save a handle to it to record bootup errors
+        self._bootup_thread = threading.Thread(target=self._monitor_bootup, daemon=True)
+        self._bootup_thread.start()
 
-    def _monitor_bootup():
-        pass
 
-    def _ensure_terminated(self):
-        """Terminate the subprocess if it exists
+    def _monitor_bootup(self):
+        """Ran in a background thread to complete the BOOTING -> READY transition
 
-        _proc_mutex should be locked before calling this
-        """
-        if self._tgis_state != _TGISState.STOPPED:
-            self._tgis_proc.terminate()
-            self._tgis_proc = None
-            self._tgis_state = _TGISState.STOPPED
-
-    def _poll_until_ready(self):
-        """Polls the TGIS process until if finishes booting
-
-        The polling is guarded with a timeout.
+        Polls the TGIS process until if finishes booting. The polling is guarded
+        with a timeout.
         """
         # Wait for the server to be ready
         start_t = time.time()
         while True:
-            time.sleep(self._health_poll_delay.total_seconds())
+            time.sleep(self._bootup_poll_delay.total_seconds())
 
-            # check if the process stopped while waiting
-            try:
-                if self._tgis_proc.poll() is not None:
-                    error(
-                        "<MTS11752287E>",
-                        RuntimeError(
+            # if we are not still booting, exit
+            # another thread could have caused a state transition
+            if self._tgis_state != _TGISState.BOOTING:
+                return
+
+            # check if the process stopped/crashed
+            with self._mutex:
+                try:
+                    if self._tgis_proc.poll() is not None:
+                        if self._tgis_state != _TGISState.STOPPED:
+                            self._ensure_terminated()
+                        exc = RuntimeError(
                             "TGIS failed to boot up with the model. See logs for details"
-                        ),
+                        )
+                        self._bootup_exc = exc
+                        error("<MTS11752287E>", exc)
+                except AttributeError:
+                    if self._tgis_state != _TGISState.STOPPED:
+                        self._ensure_terminated()
+                    exc = RuntimeError(
+                        "TGIS process terminated while waiting for it to boot with the model"
                     )
-            except AttributeError:
-                error(
-                    "<MTS26557152E>",
-                    RuntimeError(
-                        "TGIS process removed while waiting for it to boot with the model"
-                    ),
-                )
+                    self._bootup_exc = exc
+                    error("<MTS26557152E>", exc)
 
             # see if we can get a passing health check request
             try:
                 if self._health_check():
-                    # TODO: should lock mutex during this state transition?
-                    # if the health check passes, we are good to go
-                    log.debug("TGIS booted for model [%s]", self._model_path)
-                    self._tgis_state = _TGISState.READY
-                    break
+                    with self._mutex:
+                        # double check that we are still in the booting state
+                        if not self._tgis_state == _TGISState.BOOTING:
+                            return
+                        # if the health check passes, we are good to go
+                        self._create_grpc_client()
+                        log.debug("_monitor_bootup setting state to READY")
+                        self._tgis_state = _TGISState.READY
+                        log.debug("TGIS booted for model [%s]", self._model_path)
+                        return
             except requests.exceptions.RequestException as e:
                 # Ignore ConnectionErrors that are expected during boot up
                 if isinstance(e, requests.exceptions.ConnectionError):
                     continue
-
-                log.warning("<MTS96271549W>", "TGIS health check failed in _poll_until_ready: %s", e)
-
+                log.warning("<MTS96271549W>", "TGIS health check failed in _monitor_bootup: %s", repr(e))
 
             # limit how long we wait before giving up
             if time.time() - start_t >= self._load_timeout.total_seconds():
-                self.terminate
-                error(
-                    "<MTS23188245E>",
-                    RuntimeError(
+                with self._mutex:
+                    # double check that we are still in the booting state
+                    if not self._tgis_state == _TGISState.BOOTING:
+                        return
+
+                    self._ensure_terminated()
+                    exc = RuntimeError(
                         "TGIS failed to boot up with the model within the timeout"
-                    ),
-                )
+                    )
+                    self._bootup_exc = exc
+                    error("<MTS23188245E>", exc)
 
     def _health_check(self):
         """Health check to a TGIS server"""
         if self._tgis_proc is None:
+            log.debug2("_health_check called without subprocess running")
             return False
 
         resp = requests.get(
             f"http://localhost:{self._http_port}/health",
             timeout=self._health_poll_timeout.total_seconds(),
         )
+        log.debug2("_health_check result [code=%s]", resp.status_code)
 
         return resp.status_code == 200
 
@@ -222,25 +272,78 @@ class ManagedTGISSubprocess():
         channel = grpc.insecure_channel(self._hostname)
         self._client = generation_pb2_grpc.GenerationServiceStub(channel)
 
+    def _handle_autorecovery(self):
+        """Check if the subprocess might be unhealthy and recover"""
+
+        # if we are booting, do nothing
+        if self._tgis_state == _TGISState.BOOTING:
+            log.debug("Autorecovery skipped because the process is booting")
+            return
+
+        # if the health check passes, do nothing
+        try:
+            if self._health_check():
+                log.debug("Autorecovery skipped because health check is passing")
+                return
+        except:
+            # handle recovery below
+            pass
+
+        # restart the process
+        with self._mutex:
+            # double check that we aren't already booting
+            if self._tgis_state == _TGISState.BOOTING:
+                log.debug("Autorecovery (in mutex) skipped because the process is booting")
+                return
+
+            log.warning("Autorecovery is restarting TGIS")
+            self._launch()
+
+        return
+
+
+class _MockRPCError(grpc.RpcError):
+    """Mocks an RpcError but is generated outside the gRPC code"""
+    def __init__(self, code):
+        self.code = code
+
+    def code(self):
+        return self.code
+
 # used to create closures over the subprocess that can be called like a
 # client stub, but have a auto-recovering client to the subprocess
-class _wrapped_rpc():
+class _WrappedRPC():
     def __init__(self, subprocess, rpc_name):
         self.subprocess = subprocess
         self.rpc_name = rpc_name
 
-    def __call__(self, *args, **kwargs):
-        # TODO: Error handling that re-launches the subprocess if calls fail
-        log.debug3("Calling wrapped RPC [%s]", self.rpc_name)
-        return getattr(self.subprocess._client, self.rpc_name).__call__(*args, **kwargs)
+    def __call__(self, request, context=None):
+        # TODO: should wait for the subprocess up until the deadline if booting?
+        if not self.subprocess.is_ready():
+            raise _MockRPCError(grpc.StatusCode.UNAVAILABLE)
 
+        try:
+            log.debug3("Calling wrapped RPC [%s]", self.rpc_name)
+            return getattr(self.subprocess._client, self.rpc_name).__call__(request, context)
+        except grpc.RpcError as rpc_error:
+            if rpc_error.code() == grpc.StatusCode.CANCELLED:
+                raise rpc_error
+            elif rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+                # trigger a check on the process
+                threading.Thread(target=self.subprocess._handle_autorecovery, daemon=True).start()
+                raise rpc_error
+            else:
+                exc_chain = RuntimeError("Unhandled RPC error")
+                exc_chain.__cause__ = rpc_error
+                error("<MTS86992919W>", exc_chain)
+                raise rpc_error
 
 class GenerationServiceStubWrapper():
     def __init__(self, subprocess: ManagedTGISSubprocess):
         # use the attributes of the Servicer to discover the names of the RPCs
-        # the Stub creates its rpcs in __init__, so we can't use that
+        # the Stub creates its rpcs as attributes in __init__, so we can't use that
         rpc_names = [func for func in dir(generation_pb2_grpc.GenerationServiceServicer) if callable(getattr(generation_pb2_grpc.GenerationServiceServicer, func)) and not func.startswith("__")]
 
         for rpc in rpc_names:
             log.debug3("Creating wrapped RPC call for [%s]", rpc)
-            setattr(self, rpc, _wrapped_rpc(subprocess, rpc))
+            setattr(self, rpc, _WrappedRPC(subprocess, rpc))

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -1,0 +1,246 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Managed TGIS subprocess with automatic fault recovery
+
+Creates a wrapped gRPC client that knows that the gRPC server is managed as a
+subprocess.
+"""
+
+# Standard
+from datetime import timedelta
+from enum import Enum
+from threading import Lock
+import os
+import shlex
+import subprocess
+import time
+
+# Third Party
+import grpc
+import requests
+
+# First Party
+from caikit.core.toolkit.errors import error_handler
+import alog
+
+# Local
+from .protobufs import generation_pb2_grpc
+
+log = alog.use_channel("TGISPROC")
+error = error_handler.get(log)
+
+class _TGISState(Enum):
+    UNKNOWN = 0
+    STOPPED = 1 # subprocess does not exist
+    BOOTING = 2 # attempting to load the model
+    READY = 3 # ready for inference requests
+
+# pylint: disable=too-many-instance-attributes
+class ManagedTGISSubprocess():
+    # TODO: consider potential refactor with TGIS connection class for
+    # the many instance attributes
+    def __init__(self,
+        model_path: str,
+        grpc_port: int = 50055,
+        http_port: int = 3000,
+        health_poll_delay: timedelta = None,
+        health_poll_timeout: timedelta = None,
+        load_timeout: timedelta = None,
+    ):
+        # NOTE: Needs to be set before any possible errors since it's used in
+        #   the destructor
+        self._mutex = Lock()
+        self._tgis_proc = None
+        self._tgis_state: _TGISState = _TGISState.STOPPED
+
+        if not health_poll_delay:
+            health_poll_delay = timedelta(seconds=1)
+        if not health_poll_timeout:
+            health_poll_timeout = timedelta(seconds=1)
+        if not load_timeout:
+            load_timeout = timedelta(seconds=30)
+
+        # parameters of the TGIS subprocess
+        self._model_path = model_path
+        self._grpc_port = grpc_port
+        self._http_port = http_port
+        self._health_poll_delay = health_poll_delay
+        self._health_poll_timeout = health_poll_timeout
+        self._load_timeout = load_timeout
+
+        self._hostname = f"localhost:{self._grpc_port}"
+
+        self._client = None
+
+    def __del__(self):
+        self.terminate()
+
+    def is_ready(self) -> bool:
+        return self._tgis_state == _TGISState.READY
+
+    def get_client(self):
+        """Creates a gRPC client to the subprocess
+
+        Returns None if the subprocess is not ready and doesn't have an internal client
+        """
+        if self._client:
+            # create a wrapped gRPC client stub that defers to self._client
+            return GenerationServiceStubWrapper(self)
+
+        log.warning("<MTS7717800W>", "get_client called with _client set to None")
+        return None
+
+    def launch(self):
+        """Launch the subprocess or restart it if it exists"""
+        with self._mutex:
+            self._launch()
+
+    def terminate(self):
+        """Terminate the subprocess, wait for it to exit"""
+        with self._mutex:
+            self._ensure_terminated()
+
+    def _launch(self):
+        """Launch the subprocess or restart if it exists
+
+        _proc_mutex should be locked before calling
+        """
+        self._ensure_terminated()
+
+        log.debug("Launching TGIS subprocess for model [%s]", self._model_path)
+
+        # Launch TGIS
+        launch_cmd = " ".join(
+            [
+                "text-generation-launcher",
+                f"--num-shard 1",
+                f"--model-name {self._model_path}",
+                f"--port {self._http_port}",
+            ]
+        )
+        log.debug2("TGIS command: [%s]", launch_cmd)
+        env = os.environ.copy()
+        env["GRPC_PORT"] = str(self._grpc_port)
+        # Long running process
+        # pylint: disable=consider-using-with
+        self._tgis_proc = subprocess.Popen(shlex.split(launch_cmd), env=env)
+        self._tgis_state = _TGISState.BOOTING
+        self._create_grpc_client()
+
+    def _monitor_bootup():
+        pass
+
+    def _ensure_terminated(self):
+        """Terminate the subprocess if it exists
+
+        _proc_mutex should be locked before calling this
+        """
+        if self._tgis_state != _TGISState.STOPPED:
+            self._tgis_proc.terminate()
+            self._tgis_proc = None
+            self._tgis_state = _TGISState.STOPPED
+
+    def _poll_until_ready(self):
+        """Polls the TGIS process until if finishes booting
+
+        The polling is guarded with a timeout.
+        """
+        # Wait for the server to be ready
+        start_t = time.time()
+        while True:
+            time.sleep(self._health_poll_delay.total_seconds())
+
+            # check if the process stopped while waiting
+            try:
+                if self._tgis_proc.poll() is not None:
+                    error(
+                        "<MTS11752287E>",
+                        RuntimeError(
+                            "TGIS failed to boot up with the model. See logs for details"
+                        ),
+                    )
+            except AttributeError:
+                error(
+                    "<MTS26557152E>",
+                    RuntimeError(
+                        "TGIS process removed while waiting for it to boot with the model"
+                    ),
+                )
+
+            # see if we can get a passing health check request
+            try:
+                if self._health_check():
+                    # TODO: should lock mutex during this state transition?
+                    # if the health check passes, we are good to go
+                    log.debug("TGIS booted for model [%s]", self._model_path)
+                    self._tgis_state = _TGISState.READY
+                    break
+            except requests.exceptions.RequestException as e:
+                # Ignore ConnectionErrors that are expected during boot up
+                if isinstance(e, requests.exceptions.ConnectionError):
+                    continue
+
+                log.warning("<MTS96271549W>", "TGIS health check failed in _poll_until_ready: %s", e)
+
+
+            # limit how long we wait before giving up
+            if time.time() - start_t >= self._load_timeout.total_seconds():
+                self.terminate
+                error(
+                    "<MTS23188245E>",
+                    RuntimeError(
+                        "TGIS failed to boot up with the model within the timeout"
+                    ),
+                )
+
+    def _health_check(self):
+        """Health check to a TGIS server"""
+        if self._tgis_proc is None:
+            return False
+
+        resp = requests.get(
+            f"http://localhost:{self._http_port}/health",
+            timeout=self._health_poll_timeout.total_seconds(),
+        )
+
+        return resp.status_code == 200
+
+    def _create_grpc_client(self):
+        log.debug("Connecting to TGIS at [%s] INSECURE", self._hostname)
+        channel = grpc.insecure_channel(self._hostname)
+        self._client = generation_pb2_grpc.GenerationServiceStub(channel)
+
+# used to create closures over the subprocess that can be called like a
+# client stub, but have a auto-recovering client to the subprocess
+class _wrapped_rpc():
+    def __init__(self, subprocess, rpc_name):
+        self.subprocess = subprocess
+        self.rpc_name = rpc_name
+
+    def __call__(self, *args, **kwargs):
+        # TODO: Error handling that re-launches the subprocess if calls fail
+        log.debug3("Calling wrapped RPC [%s]", self.rpc_name)
+        return getattr(self.subprocess._client, self.rpc_name).__call__(*args, **kwargs)
+
+
+class GenerationServiceStubWrapper():
+    def __init__(self, subprocess: ManagedTGISSubprocess):
+        # use the attributes of the Servicer to discover the names of the RPCs
+        # the Stub creates its rpcs in __init__, so we can't use that
+        rpc_names = [func for func in dir(generation_pb2_grpc.GenerationServiceServicer) if callable(getattr(generation_pb2_grpc.GenerationServiceServicer, func)) and not func.startswith("__")]
+
+        for rpc in rpc_names:
+            log.debug3("Creating wrapped RPC call for [%s]", rpc)
+            setattr(self, rpc, _wrapped_rpc(subprocess, rpc))

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -15,7 +15,6 @@
 """
 
 # Standard
-from datetime import timedelta
 from threading import Lock
 from typing import Dict, Optional
 import os
@@ -161,9 +160,9 @@ class TGISBackend(BackendBase):
                     model_path=model_path,
                     grpc_port=self._grpc_port,
                     http_port=self._http_port,
-                    bootup_poll_delay=timedelta(seconds=self._health_poll_delay),
-                    health_poll_timeout=timedelta(seconds=self._health_poll_timeout),
-                    load_timeout=timedelta(seconds=self._load_timeout),
+                    bootup_poll_delay=self._health_poll_delay,
+                    health_poll_timeout=self._health_poll_timeout,
+                    load_timeout=self._load_timeout,
                 )
                 log.debug2("Launching TGIS subprocess")
                 self._managed_tgis.launch()
@@ -206,8 +205,9 @@ class TGISBackend(BackendBase):
 
     @property
     def model_loaded(self) -> bool:
-        return not self.local_tgis or (self._managed_tgis is not None and self._managed_tgis.is_ready())
-
+        return not self.local_tgis or (
+            self._managed_tgis is not None and self._managed_tgis.is_ready()
+        )
 
     ## Impl ##
 

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -161,7 +161,7 @@ class TGISBackend(BackendBase):
                     model_path=model_path,
                     grpc_port=self._grpc_port,
                     http_port=self._http_port,
-                    health_poll_delay=timedelta(seconds=self._health_poll_delay),
+                    bootup_poll_delay=timedelta(seconds=self._health_poll_delay),
                     health_poll_timeout=timedelta(seconds=self._health_poll_timeout),
                     load_timeout=timedelta(seconds=self._load_timeout),
                 )
@@ -169,7 +169,7 @@ class TGISBackend(BackendBase):
                 self._managed_tgis.launch()
 
             log.debug2("Waiting for TGIS subprocess to become ready")
-            self._managed_tgis._poll_until_ready()
+            self._managed_tgis.wait_until_ready()
 
         if not self._client:
             self._setup_client()

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -163,6 +163,7 @@ class TGISBackend(BackendBase):
                     bootup_poll_delay=self._health_poll_delay,
                     health_poll_timeout=self._health_poll_timeout,
                     load_timeout=self._load_timeout,
+                    num_gpus=self._num_gpus,
                 )
                 log.debug2("Launching TGIS subprocess")
                 self._managed_tgis.launch()

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -15,16 +15,13 @@
 """
 
 # Standard
+from datetime import timedelta
 from threading import Lock
 from typing import Dict, Optional
 import os
-import shlex
-import subprocess
-import time
 
 # Third Party
 import grpc
-import requests
 
 # First Party
 from caikit.core.module_backends.backend_types import register_backend_type
@@ -33,6 +30,7 @@ from caikit.core.toolkit.errors import error_handler
 import alog
 
 # Local
+from .managed_tgis_subprocess import ManagedTGISSubprocess
 from .protobufs import generation_pb2_grpc
 
 log = alog.use_channel("TGISBKND")
@@ -66,9 +64,9 @@ class TGISBackend(BackendBase):
 
         # NOTE: Needs to be set before any possible errors since it's used in
         #   the destructor
-        self._proc_mutex = Lock()
+        self._mutex = Lock()
         self._local_tgis = None
-        self._tgis_proc = None
+        self._managed_tgis = None
 
         # Parse the config to see if we're managing a connection to a remote
         # TGIS instance or running a local copy
@@ -91,13 +89,8 @@ class TGISBackend(BackendBase):
             self._num_gpus = local_cfg.get("num_gpus", 1)
             log.debug("Managing local TGIS with %d GPU(s)", self._num_gpus)
 
-            # Placeholder for the process that will boot lazily
-            self._tgis_proc = None
-
-            # Shared members that need to be set for the client
-            self._ca_cert, self._client_cert, self._client_key = [None] * 3
-            self._hostname = f"localhost:{self._grpc_port}"
-
+            # the local TGIS subprocess will be created later
+            self._managed_tgis = None
         else:
             log.info("<TGB20235226I>", "Managing remote TGIS connection")
             self._local_tgis = False
@@ -148,26 +141,35 @@ class TGISBackend(BackendBase):
         self._client = None
         self.unload_model("")  # TODO: Clear all models for multi-model
 
-    ## Block user interface ##
+    ## Backend user interface ##
 
     def get_client(self, model_path: str) -> generation_pb2_grpc.GenerationServiceStub:
         if self.local_tgis:
             # TODO: This will need to change for multi-model / multi-client support.
             # With local TGIS, limit the backend to a single managed TGIS process. This is to
             # simplify tracking of loads/unloads needed to support Model Mesh dynamics.
-            with self._proc_mutex:
+            with self._mutex:
                 # ValueError if a TGIS process is already running
                 error.value_check(
                     "<TGB27123275E>",
-                    self._tgis_proc is None,
+                    self._managed_tgis is None,
                     "TODO: The TGIS backend running with a local TGIS process "
                     + "only supports a single client currently",
                 )
 
-                self._initialize_tgis_proc(model_path)
+                self._managed_tgis = ManagedTGISSubprocess(
+                    model_path=model_path,
+                    grpc_port=self._grpc_port,
+                    http_port=self._http_port,
+                    health_poll_delay=timedelta(seconds=self._health_poll_delay),
+                    health_poll_timeout=timedelta(seconds=self._health_poll_timeout),
+                    load_timeout=timedelta(seconds=self._load_timeout),
+                )
+                log.debug2("Launching TGIS subprocess")
+                self._managed_tgis.launch()
 
-            # wait for the tgis server to load, but don't hold the lock the whole time
-            self._poll_until_tgis_proc_ready(model_path)
+            log.debug2("Waiting for TGIS subprocess to become ready")
+            self._managed_tgis._poll_until_ready()
 
         if not self._client:
             self._setup_client()
@@ -182,10 +184,10 @@ class TGISBackend(BackendBase):
     def unload_model(self, model_path: str):
         """Unload the model from TGIS"""
         if self.local_tgis:
-            with self._proc_mutex:
-                if self._tgis_proc:
-                    self._tgis_proc.terminate()
-                    self._tgis_proc = None
+            with self._mutex:
+                if self._managed_tgis:
+                    self._managed_tgis.terminate()
+                    self._managed_tgis = None
                     # reset the client so the connection is re-created
                     # the next time TGIS is launched
                     self._client = None
@@ -204,91 +206,10 @@ class TGISBackend(BackendBase):
 
     @property
     def model_loaded(self) -> bool:
-        return not self.local_tgis or self._tgis_proc is not None
+        return not self.local_tgis or (self._managed_tgis is not None and self._managed_tgis.is_ready())
+
 
     ## Impl ##
-
-    def _initialize_tgis_proc(self, model_path: str):
-        """Launches a local TGIS process to load and serve the  model"""
-        # NB: This function should be called with self._proc_mutex locked
-
-        log.debug("Initializing TGIS instance for model [%s]", model_path)
-
-        # Launch TGIS
-        launch_cmd = " ".join(
-            [
-                "text-generation-launcher",
-                f"--num-shard {self._num_gpus}",
-                f"--model-name {model_path}",
-                f"--port {self._http_port}",
-            ]
-        )
-        log.debug2("TGIS Command: [%s]", launch_cmd)
-        env = os.environ.copy()
-        env["GRPC_PORT"] = str(self._grpc_port)
-        # Long running process
-        # pylint: disable=consider-using-with
-        self._tgis_proc = subprocess.Popen(shlex.split(launch_cmd), env=env)
-
-    def _poll_until_tgis_proc_ready(self, model_path: str):
-        """Monitor the boot up of the TGIS process"""
-        # Wait for the server to be ready
-        start_t = time.time()
-        while True:
-            time.sleep(self._health_poll_delay)
-
-            # if the health check passes, we are good to go
-            if self._tgis_proc_health_check(bootup=True):
-                log.debug("TGIS booted for model [%s]", model_path)
-                break
-
-            # check if the process stopped while waiting
-            try:
-                if self._tgis_proc.poll() is not None:
-                    error(
-                        "<TGB11752287E>",
-                        RuntimeError(
-                            "TGIS failed to boot up with the model. See logs for details"
-                        ),
-                    )
-            except AttributeError:
-                error(
-                    "<TGB26557152E>",
-                    RuntimeError(
-                        "TGIS process removed while waiting for it to boot with the model"
-                    ),
-                )
-
-            # limit how long we wait before giving up
-            if time.time() - start_t >= self._load_timeout:
-                # unload to clean up the failed load
-                self.unload_model(model_path)
-                error(
-                    "<TGB23188245E>",
-                    RuntimeError(
-                        "TGIS failed to boot up with the model within the timeout"
-                    ),
-                )
-
-    def _tgis_proc_health_check(self, bootup=False):
-        """Health check to locally running TGIS server"""
-        if self._tgis_proc is None:
-            return False
-
-        try:
-            resp = requests.get(
-                f"http://localhost:{self._http_port}/health",
-                timeout=self._health_poll_timeout,
-            )
-        except requests.exceptions.RequestException as e:
-            # Ignore ConnectionErrors that are expected during bootup
-            if bootup and isinstance(e, requests.exceptions.ConnectionError):
-                return False
-
-            log.warning("<TGB96271549W>", "TGIS health check failed: %s", e)
-            return False
-
-        return resp.status_code == 200
 
     @staticmethod
     def _load_tls_file(file_path: Optional[str]) -> Optional[bytes]:
@@ -309,7 +230,12 @@ class TGISBackend(BackendBase):
                 return handle.read()
 
     def _setup_client(self):
-        if self._client is None:
+        if self._client is not None:
+            return
+
+        if self._local_tgis:
+            self._client = self._managed_tgis.get_client()
+        else:
             log.info(
                 "<TGB20236231I>",
                 "Initializing TGIS connection to [%s]. TLS enabled? %s. mTLS Enabled? %s",

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -37,10 +37,6 @@ from tests.tgis_mock import (
     tgis_mock_tls,
 )
 
-import alog
-
-alog.configure(default_level="debug4")
-
 ## Helpers #####################################################################
 
 # for convenience in managing the multiple parts of the fixture

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -80,7 +80,7 @@ def _launch_mock_tgis_proc_as_side_effect(mock_tgis_server: TGISMock):
 
 @pytest.fixture
 def mock_tgis_fixture():
-    mock_tgis = TGISMock(tls=False, mtls=False, health_delay=0.05)
+    mock_tgis = TGISMock(tls=False, mtls=False)
     with mock.patch("subprocess.Popen") as mock_popen_func:
         # when called, launch the mock_tgis server
         mock_popen_func.side_effect = _launch_mock_tgis_proc_as_side_effect(mock_tgis)
@@ -201,8 +201,7 @@ def test_local_tgis_run(mock_tgis_fixture: MockTGISFixture):
             "local": {
                 "grpc_port": int(mock_tgis_server.hostname.split(":")[-1]),
                 "http_port": mock_tgis_server.http_port,
-                "health_poll_delay": 0.01,
-                "health_poll_timeout": 0.01,
+                "health_poll_delay": 0.1,
             },
         }
     )
@@ -271,8 +270,7 @@ def test_local_tgis_load_timeout(mock_tgis_fixture: MockTGISFixture):
             "local": {
                 "grpc_port": int(mock_tgis_server.hostname.split(":")[-1]),
                 "http_port": mock_tgis_server.http_port,
-                "health_poll_delay": 0.01,
-                "health_poll_timeout": 0.01,
+                "health_poll_delay": 0.1,
                 "load_timeout": 0.05,
             },
         }
@@ -303,8 +301,8 @@ def test_local_tgis_autorecovery(mock_tgis_fixture: MockTGISFixture):
             "local": {
                 "grpc_port": int(mock_tgis_server.hostname.split(":")[-1]),
                 "http_port": mock_tgis_server.http_port,
-                "health_poll_delay": 0.01,
-                "health_poll_timeout": 0.01,
+                "health_poll_delay": 0.1,
+                "health_poll_timeout": 1,
             },
         }
     )

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -247,8 +247,9 @@ def test_local_tgis_load_timeout(mock_tgis_proc_ok, tgis_mock_insecure_health_de
     assert tgis_be.local_tgis
     assert not mock_tgis_proc_ok.called
 
-    # (For coverage!) make sure the health probe doesn't actually run
-    assert not tgis_be._tgis_proc_health_check()
+    # TODO: health check for coverage?
+    # # (For coverage!) make sure the health probe doesn't actually run
+    # assert not tgis_be._tgis_health_check()
 
     # Get a client handle and make sure that the server has launched
     with pytest.raises(RuntimeError):

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -283,7 +283,7 @@ def test_local_tgis_load_timeout(mock_tgis_fixture: MockTGISFixture):
     # assert not tgis_be._tgis_health_check()
 
     # Get a client handle and make sure that the server has launched
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TimeoutError):
         tgis_be.get_client("")
     assert mock_tgis_fixture.server_launched()
     assert tgis_be.local_tgis

--- a/tests/tgis_mock.py
+++ b/tests/tgis_mock.py
@@ -17,7 +17,7 @@ TGIS mock
 
 # Standard
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, Optional, Self
+from typing import Dict, Optional
 import os
 import re
 import tempfile
@@ -244,7 +244,7 @@ class TGISMock:
 
     # Implement the context manager interface
 
-    def __enter__(self) -> Self:
+    def __enter__(self):
         self.start()
         return self
 


### PR DESCRIPTION
Before this change, the TGIS server was launched in a sub-process and the code assumed that it never crashed. Now, the code detects when requests are failing and will restart the TGIS subprocess. The restart happens in a background thread so as to not block any request threads, which means that requests will still fail as the process is restarted

High level changes:
- refactor the managed TGIS subprocess to a new module
- if inference requests to TGIS return failures, a health check is sent to the subprocess and it is restarted if the health check fails
- the transition from BOOTING to READY for the subprocess is now tracked by a background daemon thread
    - this is to de-couple the request threads from the server pool from the booting of the subprocess
- wrap the gRPC client returned by `get_client(model)` into a class so that the underlying gRPC client can be re-created
    - a typical gRPC client is created with an existing channel and will attempt to reconnect with a back-off, but I think it would be better to manage the connection explicitly since we also manage the server that it connects to.
    - the wrapping layer is also where errors TGIS are checked to determine when to restart the process
- update test mocks to enable testing the auto-recovery
    - fully expose the mock servers in TGISMock (not just connection information) so that the test can stop the servers
    - combine the components of the subprocess mocking into MockTGISFixture
    - have the TGISMock server(s) boot triggered by the code as a "side effect" of the `subprocess.Popen` mock
    - allow the mock servers to be stop'd and start'd repeatedly (creating a new thread on start)