### PR TITLE
:package: Update caikit dependency allowed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit>=0.2.0,<0.6.0", # Core abstractions
+    "caikit>=0.2.0,<0.8.0", # Core abstractions
     "grpcio>=1.35.0,<2.0", # Client calls to TGIS
     "requests>=2.28.2,<3", # Health check calls to TGIS
 ]


### PR DESCRIPTION
### Changes
- Update caikit maximum version allowed to enable users to use caikit `0.7.0` recently released.