### PR TITLE
:arrow_up: Bump upper bound for caikit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit>=0.2.0,<0.12.0", # Core abstractions
+    "caikit>=0.2.0,<0.13.0", # Core abstractions
     "grpcio>=1.35.0,<2.0", # Client calls to TGIS
     "requests>=2.28.2,<3", # Health check calls to TGIS
 ]


### PR DESCRIPTION
Small breaking interface change made for caikit 0.12.0: https://github.com/caikit/caikit/releases/tag/v0.12.0, does not directly affect `caikit-tgis-backend` here but we want to allow for this version