### PR TITLE
Multi connection 17

### DIFF
--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -1,0 +1,107 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Encapsulate the creation of a TGIS Connection"""
+
+# Standard
+from dataclasses import dataclass
+from typing import Optional
+
+# First Party
+from caikit.core.toolkit.errors import error_handler
+import alog
+
+log = alog.use_channel("TGCONN")
+error = error_handler.get(log)
+
+
+@dataclass
+class TLSFilePair:
+    cert_file: str
+    key_file: str
+
+
+@dataclass
+class TGISConnection:
+
+    # Class members
+    hostname: str
+    ca_cert_file: Optional[str] = None
+    client_tls: Optional[TLSFilePair] = None
+
+    # Class constants
+    HOSTNAME_KEY = "hostname"
+    HOSTNAME_TEMPLATE_KEY = "hostname_template"
+    HOSTNAME_TEMPLATE_MODEL_ID = "model_id"
+    CA_CERT_FILE_KEY = "ca_cert_file"
+    CLIENT_CERT_FILE_KEY = "client_cert_file"
+    CLIENT_KEY_FILE_KEY = "client_key_file"
+
+    @classmethod
+    def from_config(cls, config: dict) -> Optional["TGISConnection"]:
+        """Create an instance from a connection config blob"""
+        return cls._from_cfg(config.get(cls.HOSTNAME_KEY), config)
+
+    @classmethod
+    def from_template(cls, model_id: str, config: dict) -> Optional["TGISConnection"]:
+        """Create an instance from a connection template and a model_id"""
+        hostname_template = config.get(cls.HOSTNAME_TEMPLATE_KEY)
+        if hostname_template:
+            template_raw = f"{cls.HOSTNAME_TEMPLATE_MODEL_ID}"
+            error.value_check(
+                "<TGB76465562E>",
+                template_raw in hostname_template,
+                "Template [{}] does not contain [{}] as a template field (e.g. {})",
+                hostname_template,
+                cls.HOSTNAME_TEMPLATE_MODEL_ID,
+                template_raw,
+            )
+            hostname = hostname_template.format(
+                **{
+                    cls.HOSTNAME_TEMPLATE_MODEL_ID: model_id,
+                }
+            )
+            log.debug("Resolved hostname [%s] for model %s", hostname, model_id)
+            return cls._from_cfg(hostname, config)
+
+    @classmethod
+    def _from_cfg(cls, hostname: str, config: dict) -> Optional["TGISConnection"]:
+        if hostname:
+            ca_cert = config.get(cls.CA_CERT_FILE_KEY) or None
+            client_cert = config.get(cls.CLIENT_CERT_FILE_KEY) or None
+            client_key = config.get(cls.CLIENT_KEY_FILE_KEY) or None
+            log.debug2("CA Cert File: %s", ca_cert)
+            log.debug2("Client Cert File: %s", client_cert)
+            log.debug2("Client Key File: %s", client_key)
+
+            error.value_check(
+                "<TGB79518571E>",
+                ca_cert or (not client_cert and not client_key),
+                "Cannot set client TLS ({}/{}) without CA ({})",
+                cls.CLIENT_CERT_FILE_KEY,
+                cls.CLIENT_KEY_FILE_KEY,
+                cls.CA_CERT_FILE_KEY,
+            )
+            error.value_check(
+                "<TGB79518572E>",
+                (client_cert and client_key) or (not client_cert and not client_key),
+                "Must set both {} and {} or neither",
+                cls.CLIENT_CERT_FILE_KEY,
+                cls.CLIENT_KEY_FILE_KEY,
+            )
+            client_tls = (
+                TLSFilePair(cert_file=client_cert, key_file=client_key)
+                if client_cert
+                else None
+            )
+            return cls(hostname=hostname, ca_cert_file=ca_cert, client_tls=client_tls)

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -21,6 +21,9 @@ from typing import Optional
 from caikit.core.toolkit.errors import error_handler
 import alog
 
+# Local
+from .protobufs import generation_pb2_grpc
+
 log = alog.use_channel("TGCONN")
 error = error_handler.get(log)
 
@@ -38,45 +41,29 @@ class TGISConnection:
     hostname: str
     ca_cert_file: Optional[str] = None
     client_tls: Optional[TLSFilePair] = None
+    _client: Optional[generation_pb2_grpc.GenerationServiceStub] = None
 
     # Class constants
     HOSTNAME_KEY = "hostname"
-    HOSTNAME_TEMPLATE_KEY = "hostname_template"
     HOSTNAME_TEMPLATE_MODEL_ID = "model_id"
     CA_CERT_FILE_KEY = "ca_cert_file"
     CLIENT_CERT_FILE_KEY = "client_cert_file"
     CLIENT_KEY_FILE_KEY = "client_key_file"
 
     @classmethod
-    def from_config(cls, config: dict) -> Optional["TGISConnection"]:
-        """Create an instance from a connection config blob"""
-        return cls._from_cfg(config.get(cls.HOSTNAME_KEY), config)
-
-    @classmethod
-    def from_template(cls, model_id: str, config: dict) -> Optional["TGISConnection"]:
+    def from_config(cls, model_id: str, config: dict) -> Optional["TGISConnection"]:
         """Create an instance from a connection template and a model_id"""
-        hostname_template = config.get(cls.HOSTNAME_TEMPLATE_KEY)
-        if hostname_template:
+        hostname = config.get(cls.HOSTNAME_KEY)
+        if hostname:
             template_raw = f"{cls.HOSTNAME_TEMPLATE_MODEL_ID}"
-            error.value_check(
-                "<TGB76465562E>",
-                template_raw in hostname_template,
-                "Template [{}] does not contain [{}] as a template field (e.g. {})",
-                hostname_template,
-                cls.HOSTNAME_TEMPLATE_MODEL_ID,
-                template_raw,
-            )
-            hostname = hostname_template.format(
+            hostname = hostname.format(
                 **{
                     cls.HOSTNAME_TEMPLATE_MODEL_ID: model_id,
                 }
             )
             log.debug("Resolved hostname [%s] for model %s", hostname, model_id)
-            return cls._from_cfg(hostname, config)
 
-    @classmethod
-    def _from_cfg(cls, hostname: str, config: dict) -> Optional["TGISConnection"]:
-        if hostname:
+            # Pull out the TLS info
             ca_cert = config.get(cls.CA_CERT_FILE_KEY) or None
             client_cert = config.get(cls.CLIENT_CERT_FILE_KEY) or None
             client_key = config.get(cls.CLIENT_KEY_FILE_KEY) or None
@@ -105,3 +92,64 @@ class TGISConnection:
                 else None
             )
             return cls(hostname=hostname, ca_cert_file=ca_cert, client_tls=client_tls)
+
+    @property
+    def tls_enabled(self) -> bool:
+        return self.ca_cert_file is not None
+
+    @property
+    def mtls_enabled(self) -> bool:
+        return None not in [
+            self.ca_cert_file,
+            self.client_cert_file,
+            self.client_key_file,
+        ]
+
+    def get_client(self) -> generation_pb2_grpc.GenerationServiceStub:
+        """Get a grpc client for the connection"""
+        if self._client is None:
+            log.info(
+                "<TGB20236231I>",
+                "Initializing TGIS connection to [%s]. TLS enabled? %s. mTLS Enabled? %s",
+                self.hostname,
+                self.tls_enabled,
+                self.mtls_enabled,
+            )
+            if not self.tls_enabled:
+                log.debug("Connecting to TGIS at [%s] INSECURE", self.hostname)
+                channel = grpc.insecure_channel(self.hostname)
+            else:
+                log.debug("Connecting to TGIS at [%s] SECURE", self.hostname)
+                creds_kwargs = {
+                    "root_certificates": self._load_tls_file(self.ca_cert_file)
+                }
+                if self.mtls_enabled:
+                    log.debug("Enabling mTLS for TGIS connection")
+                    creds_kwargs["certificate_chain"] = self._load_tls_file(
+                        self.client_cert_file
+                    )
+                    creds_kwargs["private_key"] = self._load_tls_file(
+                        self.client_key_file
+                    )
+                credentials = grpc.ssl_channel_credentials(**creds_kwargs)
+                channel = grpc.secure_channel(self.hostname, credentials=credentials)
+            self._client = generation_pb2_grpc.GenerationServiceStub(channel)
+        return self._client
+
+    @staticmethod
+    def _load_tls_file(file_path: Optional[str]) -> Optional[bytes]:
+        error.type_check(
+            "<TGB20235227E>",
+            str,
+            allow_none=True,
+            file_path=file_path,
+        )
+        if file_path is not None:
+            error.value_check(
+                "<TGB20235228E>",
+                os.path.isfile(file_path),
+                "Invalid TLS file path: {}",
+                file_path,
+            )
+            with open(file_path, "rb") as handle:
+                return handle.read()

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -59,7 +59,6 @@ class TGISConnection:
         """Create an instance from a connection template and a model_id"""
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:
-            template_raw = f"{cls.HOSTNAME_TEMPLATE_MODEL_ID}"
             hostname = hostname.format(
                 **{
                     cls.HOSTNAME_TEMPLATE_MODEL_ID: model_id,

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -17,6 +17,7 @@ Unit tests for TGIS backend
 
 # Standard
 from unittest import mock
+import os
 import time
 
 # Third Party
@@ -103,7 +104,8 @@ def test_tgis_backend_config_valid_insecure(tgis_mock_insecure):
     blob for an insecure server
     """
     tgis_be = TGISBackend({"connection": {"hostname": tgis_mock_insecure.hostname}})
-    tgis_be.get_client("").Generate(
+    model_id = "test-model"
+    tgis_be.get_client(model_id).Generate(
         generation_pb2.BatchedGenerationRequest(
             requests=[
                 generation_pb2.GenerationRequest(text="Hello world"),
@@ -111,8 +113,10 @@ def test_tgis_backend_config_valid_insecure(tgis_mock_insecure):
         ),
     )
     assert tgis_be.is_started
-    assert not tgis_be.tls_enabled
-    assert not tgis_be.mtls_enabled
+    conn = tgis_be.get_connection(model_id)
+    assert conn
+    assert not conn.tls_enabled
+    assert not conn.mtls_enabled
 
 
 def test_tgis_backend_config_valid_tls(tgis_mock_tls):
@@ -127,7 +131,8 @@ def test_tgis_backend_config_valid_tls(tgis_mock_tls):
             },
         }
     )
-    tgis_be.get_client("").Generate(
+    model_id = "test-model"
+    tgis_be.get_client(model_id).Generate(
         generation_pb2.BatchedGenerationRequest(
             requests=[
                 generation_pb2.GenerationRequest(text="Hello world"),
@@ -135,8 +140,10 @@ def test_tgis_backend_config_valid_tls(tgis_mock_tls):
         ),
     )
     assert tgis_be.is_started
-    assert tgis_be.tls_enabled
-    assert not tgis_be.mtls_enabled
+    conn = tgis_be.get_connection(model_id)
+    assert conn
+    assert conn.tls_enabled
+    assert not conn.mtls_enabled
 
 
 def test_tgis_backend_config_valid_mtls(tgis_mock_mtls):
@@ -153,7 +160,8 @@ def test_tgis_backend_config_valid_mtls(tgis_mock_mtls):
             },
         }
     )
-    tgis_be.get_client("").Generate(
+    model_id = "test-model"
+    tgis_be.get_client(model_id).Generate(
         generation_pb2.BatchedGenerationRequest(
             requests=[
                 generation_pb2.GenerationRequest(text="Hello world"),
@@ -161,20 +169,31 @@ def test_tgis_backend_config_valid_mtls(tgis_mock_mtls):
         ),
     )
     assert tgis_be.is_started
-    assert tgis_be.tls_enabled
-    assert tgis_be.mtls_enabled
+    conn = tgis_be.get_connection(model_id)
+    assert conn
+    assert conn.tls_enabled
+    assert conn.mtls_enabled
 
 
 def test_stop():
-    """Make sure that a working backend instance can be stopped (cov!)"""
-    tgis_be = TGISBackend({"connection": {"hostname": "localhost:12345"}})
+    """Make sure that a working backend instance can be stopped"""
+    tgis_be = TGISBackend({"connection": {"hostname": "foo.bar.{model_id}:12345"}})
     assert not tgis_be.is_started
-    tgis_be.start()
+
+    # Add two models with get_client
+    model_id1 = "foo"
+    model_id2 = "bar"
+    tgis_be.get_client(model_id1)
+    tgis_be.get_client(model_id2)
     assert tgis_be.is_started
-    assert tgis_be._client is not None
+    assert tgis_be.get_connection(model_id1)
+    assert tgis_be.get_connection(model_id2)
+
+    # Stop the backend and make sure both models get removed
     tgis_be.stop()
     assert not tgis_be.is_started
-    assert tgis_be._client is None
+    assert not tgis_be.get_connection(model_id1)
+    assert not tgis_be.get_connection(model_id2)
 
 
 def test_construct_run_local():
@@ -183,6 +202,7 @@ def test_construct_run_local():
     """
     assert TGISBackend({}).local_tgis
     assert TGISBackend({"connection": {}}).local_tgis
+    assert TGISBackend({"remote_models": {}}).local_tgis
 
     # When setting the connection to empty via the env, this is what it looks
     # like, so we want to make sure this doesn't error
@@ -192,7 +212,6 @@ def test_construct_run_local():
 def test_local_tgis_run(mock_tgis_fixture: MockTGISFixture):
     """Test that a "local tgis" (mocked) can be booted and maintained"""
     mock_tgis_server: TGISMock = mock_tgis_fixture.mock_tgis_server
-
     tgis_be = TGISBackend(
         {
             "local": {
@@ -357,30 +376,84 @@ def test_no_updated_config():
         tgis_be.register_config({"connection": {"hostname": "localhost:54321"}})
 
 
-def test_invalid_connection():
+@pytest.mark.parametrize(
+    "params",
+    [
+        ("not a dict", TypeError),
+        ({"hostname": "localhost"}, ValueError),
+        ({"hostname": "foo:123", "ca_cert_file": 1}, TypeError),
+        # Missing TLS Files
+        ({"hostname": "foo:123", "ca_cert_file": "not there"}, ValueError),
+        (
+            {
+                "hostname": "foo:123",
+                "ca_cert_file": __file__,
+                "client_cert_file": "not there",
+                "client_key_file": __file__,
+            },
+            ValueError,
+        ),
+        (
+            {
+                "hostname": "foo:123",
+                "ca_cert_file": __file__,
+                "client_cert_file": __file__,
+                "client_key_file": "not there",
+            },
+            ValueError,
+        ),
+        # TLS Files as dirs
+        (
+            {"hostname": "foo:123", "ca_cert_file": os.path.dirname(__file__)},
+            ValueError,
+        ),
+        (
+            {
+                "hostname": "foo:123",
+                "ca_cert_file": __file__,
+                "client_cert_file": os.path.dirname(__file__),
+                "client_key_file": __file__,
+            },
+            ValueError,
+        ),
+        (
+            {
+                "hostname": "foo:123",
+                "ca_cert_file": __file__,
+                "client_cert_file": __file__,
+                "client_key_file": os.path.dirname(__file__),
+            },
+            ValueError,
+        ),
+        # Bad TLS File combos
+        (
+            {
+                "hostname": "foo:123",
+                "ca_cert_file": __file__,
+                "client_cert_file": __file__,
+            },
+            ValueError,
+        ),
+        (
+            {
+                "hostname": "foo:123",
+                "ca_cert_file": __file__,
+                "client_key_file": __file__,
+            },
+            ValueError,
+        ),
+        (
+            {
+                "hostname": "foo:123",
+                "client_cert_file": __file__,
+                "client_key_file": __file__,
+            },
+            ValueError,
+        ),
+    ],
+)
+def test_invalid_connection(params):
     """Make sure that invalid connections cause errors"""
-    # All forms of invalid hostname
-    with pytest.raises(TypeError):
-        TGISBackend({"connection": "not a dict"})
-    with pytest.raises(ValueError):
-        TGISBackend({"connection": {"hostname": "localhost"}})
-
-    # All forms of invalid TLS paths
-    with pytest.raises(TypeError):
-        TGISBackend(
-            {
-                "connection": {
-                    "hostname": "localhost:12345",
-                    "ca_cert_file": 12345,
-                },
-            }
-        )
-    with pytest.raises(ValueError):
-        TGISBackend(
-            {
-                "connection": {
-                    "hostname": "localhost:12345",
-                    "ca_cert_file": "not there",
-                },
-            }
-        )
+    conn, error_type = params
+    with pytest.raises(error_type):
+        TGISBackend({"connection": conn})

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -21,9 +21,11 @@ import pytest
 # Local
 from caikit_tgis_backend.tgis_connection import TGISConnection
 
+## Happy Paths #################################################################
+
 
 def test_happy_path_no_tls():
-    conn = TGISConnection.from_config({TGISConnection.HOSTNAME_KEY: "foo.bar:1234"})
+    conn = TGISConnection.from_config("", {TGISConnection.HOSTNAME_KEY: "foo.bar:1234"})
     assert conn.hostname == "foo.bar:1234"
     assert conn.ca_cert_file is None
     assert conn.client_tls is None
@@ -33,9 +35,9 @@ def test_happy_path_template():
     template_piece = "{{{}}}".format(TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID)
     template = f"foo.{template_piece}.bar.{template_piece}"
     model_id = "some/model"
-    conn = TGISConnection.from_template(
+    conn = TGISConnection.from_config(
         model_id,
-        {TGISConnection.HOSTNAME_TEMPLATE_KEY: template},
+        {TGISConnection.HOSTNAME_KEY: template},
     )
     assert conn.hostname == template.format(
         **{TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID: model_id}
@@ -44,10 +46,11 @@ def test_happy_path_template():
 
 def test_happy_path_tls():
     conn = TGISConnection.from_config(
+        "",
         {
             TGISConnection.HOSTNAME_KEY: "foo.bar:1234",
             TGISConnection.CA_CERT_FILE_KEY: "ca.crt",
-        }
+        },
     )
     assert conn.hostname == "foo.bar:1234"
     assert conn.ca_cert_file is "ca.crt"
@@ -56,12 +59,13 @@ def test_happy_path_tls():
 
 def test_happy_path_mtls():
     conn = TGISConnection.from_config(
+        "",
         {
             TGISConnection.HOSTNAME_KEY: "foo.bar:1234",
             TGISConnection.CA_CERT_FILE_KEY: "ca.crt",
             TGISConnection.CLIENT_CERT_FILE_KEY: "client.crt",
             TGISConnection.CLIENT_KEY_FILE_KEY: "client.key",
-        }
+        },
     )
     assert conn.hostname == "foo.bar:1234"
     assert conn.ca_cert_file is "ca.crt"

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -1,0 +1,70 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the TGISConnection class
+"""
+
+# Third Party
+import pytest
+
+# Local
+from caikit_tgis_backend.tgis_connection import TGISConnection
+
+
+def test_happy_path_no_tls():
+    conn = TGISConnection.from_config({TGISConnection.HOSTNAME_KEY: "foo.bar:1234"})
+    assert conn.hostname == "foo.bar:1234"
+    assert conn.ca_cert_file is None
+    assert conn.client_tls is None
+
+
+def test_happy_path_template():
+    template_piece = "{{{}}}".format(TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID)
+    template = f"foo.{template_piece}.bar.{template_piece}"
+    model_id = "some/model"
+    conn = TGISConnection.from_template(
+        model_id,
+        {TGISConnection.HOSTNAME_TEMPLATE_KEY: template},
+    )
+    assert conn.hostname == template.format(
+        **{TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID: model_id}
+    )
+
+
+def test_happy_path_tls():
+    conn = TGISConnection.from_config(
+        {
+            TGISConnection.HOSTNAME_KEY: "foo.bar:1234",
+            TGISConnection.CA_CERT_FILE_KEY: "ca.crt",
+        }
+    )
+    assert conn.hostname == "foo.bar:1234"
+    assert conn.ca_cert_file is "ca.crt"
+    assert conn.client_tls is None
+
+
+def test_happy_path_mtls():
+    conn = TGISConnection.from_config(
+        {
+            TGISConnection.HOSTNAME_KEY: "foo.bar:1234",
+            TGISConnection.CA_CERT_FILE_KEY: "ca.crt",
+            TGISConnection.CLIENT_CERT_FILE_KEY: "client.crt",
+            TGISConnection.CLIENT_KEY_FILE_KEY: "client.key",
+        }
+    )
+    assert conn.hostname == "foo.bar:1234"
+    assert conn.ca_cert_file is "ca.crt"
+    assert conn.client_tls
+    assert conn.client_tls.cert_file == "client.crt"
+    assert conn.client_tls.key_file == "client.key"


### PR DESCRIPTION
## Description

Closes #17 

This PR extends the configuration of `TGISBackend` to allow a single instance to manage connections to multiple TGIS remote endpoints. There are two ways to configure this that can be used separately or in unison:

### Explicit `remote_models`

```yaml
config:
  remote_models:
    # Insecure TGIS
    model-one:
      hostname: some.hostname:1234
    # TGIS w/ mTLS enabled
    model-two:
      hostname: some.other.hostname:2345
      ca_cert_file: /tls/ca.pem
      client_cert_file: /tls/client.cert.pem
      client_key_file: /tls/client.key.pem
```

### Connection template

```yaml
config:
  connection:
    # Template connection with "model_id"
    hostname: some.other.{model_id}.hostname:2345
    ca_cert_file: /tls/ca.pem
    client_cert_file: /tls/client.cert.pem
    client_key_file: /tls/client.key.pem
```

## Compatibility

This change is fully backwards compatible since `connection.hostname` can omit the `{model_id}` sequence to function as a singleton explicit hostname.