### PR TITLE
Load prompt

### DIFF
--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -117,6 +117,7 @@ class TGISBackend(BackendBase):
                 health_poll_timeout=local_cfg.get("health_poll_timeout", 10),
                 load_timeout=local_cfg.get("load_timeout", 30),
                 num_gpus=local_cfg.get("num_gpus", 1),
+                prompt_dir=local_cfg.get("prompt_dir"),
             )
 
     def __del__(self):

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -189,7 +189,6 @@ class TGISBackend(BackendBase):
         # Return the client to the server
         return model_conn.get_client()
 
-    # pylint: disable=unused-argument
     def unload_model(self, model_id: str):
         """Unload the model from TGIS"""
         # If running locally, shut down the managed instance
@@ -200,6 +199,16 @@ class TGISBackend(BackendBase):
 
         # Remove the connection for this model
         self._model_connections.pop(model_id, None)
+
+    def load_prompt_artifacts(self, model_id: str, prompt_id: str, *prompt_artifacts):
+        """Load the given prompt artifacts for the given prompt against the base
+        model
+        """
+        conn = self.get_connection(model_id)
+        error.value_check(
+            "<TGB00822514E>", conn is not None, "Unknown model {}", model_id
+        )
+        conn.load_prompt_artifacts(prompt_id, *prompt_artifacts)
 
     @property
     def local_tgis(self) -> bool:

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -18,6 +18,7 @@ Unit tests for TGIS backend
 # Standard
 from unittest import mock
 import os
+import tempfile
 import time
 
 # Third Party
@@ -460,6 +461,101 @@ def test_tgis_backend_unload_multi_connection():
     tgis_be.unload_model("bar")
     assert not tgis_be.get_connection("foo", False)
     assert not tgis_be.get_connection("bar", False)
+
+
+def test_tgis_backend_config_load_prompt_artifacts():
+    """Make sure that loading prompt artifacts behaves as expected"""
+    with tempfile.TemporaryDirectory() as source_dir:
+        with tempfile.TemporaryDirectory() as prompt_dir:
+
+            # Make some source files
+            source_fnames = ["prompt1.pt", "prompt2.pt"]
+            source_files = [os.path.join(source_dir, fname) for fname in source_fnames]
+            for source_file in source_files:
+                with open(source_file, "w") as handle:
+                    handle.write("stub")
+
+            # Set up a separate prompt dir for foo and bar
+            foo_prompt_dir = os.path.join(prompt_dir, "foo")
+            bar_prompt_dir = os.path.join(prompt_dir, "bar")
+            os.makedirs(foo_prompt_dir)
+            os.makedirs(bar_prompt_dir)
+
+            # Make the backend with two remotes that support prompts and one
+            # that does not
+            tgis_be = TGISBackend(
+                {
+                    "remote_models": {
+                        "foo": {"hostname": "foo:123", "prompt_dir": foo_prompt_dir},
+                        "bar": {"hostname": "bar:123", "prompt_dir": bar_prompt_dir},
+                        "baz": {"hostname": "bar:123"},
+                    },
+                }
+            )
+
+            # Make sure loading prompts lands on the right model and prompt
+            prompt_id1 = "prompt-one"
+            prompt_id2 = "prompt-two"
+            tgis_be.load_prompt_artifacts("foo", prompt_id1, source_files[0])
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert not os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            tgis_be.load_prompt_artifacts("foo", prompt_id2, source_files[1])
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            tgis_be.load_prompt_artifacts("bar", prompt_id1, source_files[0])
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            assert os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            tgis_be.load_prompt_artifacts("bar", prompt_id2, source_files[1])
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            assert os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id2, source_fnames[1])
+            )
+
+            # Make sure non-prompt models raise
+            with pytest.raises(ValueError):
+                tgis_be.load_prompt_artifacts("baz", prompt_id1, source_files[0])
+
+            # Make sure unknown model raises
+            with pytest.raises(ValueError):
+                tgis_be.load_prompt_artifacts("buz", prompt_id1, source_files[0])
 
 
 ## Failure Tests ###############################################################


### PR DESCRIPTION
## Description

This PR adds the ability to set a `prompt_dir` field in any connection config (`connection.prompt_dir`, `remote_models.<x>.prompt_dir`, `local.prompt_dir`) that will enable `load_prompt_artifacts(model_id, prompt_id, *artifact_files)` for the given connection.