### PR TITLE
Add connection test

### DIFF
--- a/caikit_tgis_backend/generation.proto
+++ b/caikit_tgis_backend/generation.proto
@@ -2,206 +2,230 @@
   Internal service interface for FMaaS completions
  */
 
-syntax = "proto3";
-package fmaas;
+ syntax = "proto3";
+ package fmaas;
 
 
-service GenerationService {
-  // Generates text given a text prompt, for one or more inputs
-  rpc Generate (BatchedGenerationRequest) returns (BatchedGenerationResponse) {}
-  // Generates text given a single input prompt, streaming the response
-  rpc GenerateStream (SingleGenerationRequest) returns (stream GenerationResponse) {}
-  // Tokenize text
-  rpc Tokenize (BatchedTokenizeRequest) returns (BatchedTokenizeResponse) {}
-}
+ service GenerationService {
+   // Generates text given a text prompt, for one or more inputs
+   rpc Generate (BatchedGenerationRequest) returns (BatchedGenerationResponse) {}
+   // Generates text given a single input prompt, streaming the response
+   rpc GenerateStream (SingleGenerationRequest) returns (stream GenerationResponse) {}
+   // Tokenize text
+   rpc Tokenize (BatchedTokenizeRequest) returns (BatchedTokenizeResponse) {}
+   // Model info
+   rpc ModelInfo (ModelInfoRequest) returns (ModelInfoResponse) {}
+ }
 
-// ============================================================================================================
-// Generation API
+ // ============================================================================================================
+ // Generation API
 
-enum DecodingMethod {
-  GREEDY = 0;
-  SAMPLE = 1;
-}
+ enum DecodingMethod {
+   GREEDY = 0;
+   SAMPLE = 1;
+ }
 
-message BatchedGenerationRequest {
-  string model_id = 1;
-  optional string prefix_id = 2;
-  repeated GenerationRequest requests = 3;
+ message BatchedGenerationRequest {
+   string model_id = 1;
+   optional string prefix_id = 2;
+   repeated GenerationRequest requests = 3;
 
-  Parameters params = 10;
-}
+   Parameters params = 10;
+ }
 
-message SingleGenerationRequest {
-  string model_id = 1;
-  optional string prefix_id = 2;
-  GenerationRequest request = 3;
+ message SingleGenerationRequest {
+   string model_id = 1;
+   optional string prefix_id = 2;
+   GenerationRequest request = 3;
 
-  Parameters params = 10;
-}
+   Parameters params = 10;
+ }
 
-message BatchedGenerationResponse {
-  repeated GenerationResponse responses = 1;
-}
+ message BatchedGenerationResponse {
+   repeated GenerationResponse responses = 1;
+ }
 
-message GenerationRequest {
-  string text = 2;
-}
+ message GenerationRequest {
+   string text = 2;
+ }
 
-message GenerationResponse {
-  uint32 input_token_count = 6;
-  uint32 generated_token_count = 2;
-  string text = 4;
-  StopReason stop_reason = 7;
-  // Random seed used, not applicable for greedy requests
-  uint64 seed = 10;
+ message GenerationResponse {
+   uint32 input_token_count = 6;
+   uint32 generated_token_count = 2;
+   string text = 4;
+   StopReason stop_reason = 7;
+   // Random seed used, not applicable for greedy requests
+   uint64 seed = 10;
 
-  // Individual generated tokens and associated details, if requested
-  repeated TokenInfo tokens = 8;
+   // Individual generated tokens and associated details, if requested
+   repeated TokenInfo tokens = 8;
 
-  // Input tokens and associated details, if requested
-  repeated TokenInfo input_tokens = 9;
-}
+   // Input tokens and associated details, if requested
+   repeated TokenInfo input_tokens = 9;
+ }
 
-message Parameters {
-  // The high level decoding approach
-  DecodingMethod method = 1;
-  // Parameters related to sampling, applicable only when method == SAMPLING
-  SamplingParameters sampling = 2;
-  // Parameters controlling when generation should stop
-  StoppingCriteria stopping = 3;
-  // Flags to control what is returned in the response
-  ResponseOptions response = 4;
-  // Parameters for conditionally penalizing/boosting
-  // candidate tokens during decoding
-  DecodingParameters decoding = 5;
-  // Truncate to this many input tokens. Can be used to avoid requests
-  // failing due to input being longer than configured limits.
-  // Zero means don't truncate.
-  uint32 truncate_input_tokens = 6;
-}
+ message Parameters {
+   // The high level decoding approach
+   DecodingMethod method = 1;
+   // Parameters related to sampling, applicable only when method == SAMPLING
+   SamplingParameters sampling = 2;
+   // Parameters controlling when generation should stop
+   StoppingCriteria stopping = 3;
+   // Flags to control what is returned in the response
+   ResponseOptions response = 4;
+   // Parameters for conditionally penalizing/boosting
+   // candidate tokens during decoding
+   DecodingParameters decoding = 5;
+   // Truncate to this many input tokens. Can be used to avoid requests
+   // failing due to input being longer than configured limits.
+   // Zero means don't truncate.
+   uint32 truncate_input_tokens = 6;
+ }
 
-message DecodingParameters {
-  message LengthPenalty {
-    // Start the decay after this number of tokens have been generated
-    uint32 start_index = 1;
-    // Factor of exponential decay
-    float decay_factor = 2;
-  }
+ message DecodingParameters {
+   message LengthPenalty {
+     // Start the decay after this number of tokens have been generated
+     uint32 start_index = 1;
+     // Factor of exponential decay
+     float decay_factor = 2;
+   }
 
-  // Default (0.0) means no penalty (equivalent to 1.0)
-  // 1.2 is a recommended value
-  float repetition_penalty = 1;
+   // Default (0.0) means no penalty (equivalent to 1.0)
+   // 1.2 is a recommended value
+   float repetition_penalty = 1;
 
-  // Exponentially increases the score of the EOS token
-  // once start_index tokens have been generated
-  optional LengthPenalty length_penalty = 2;
-}
-
-
-message SamplingParameters {
-  // Default (0.0) means disabled (equivalent to 1.0)
-  float temperature = 1;
-  // Default (0) means disabled
-  uint32 top_k = 2;
-  // Default (0) means disabled (equivalent to 1.0)
-  float top_p = 3;
-  optional uint64 seed = 5;
-}
-
-message StoppingCriteria {
-  // Default (0) is TBD
-  uint32 max_new_tokens = 1;
-  // Default (0) is equivalent to 1
-  uint32 min_new_tokens = 2;
-  // Default (0) means no time limit
-  uint32 time_limit_millis = 3;
-  repeated string stop_sequences = 4;
-
-  //more to come
-}
-
-message ResponseOptions {
-  // Include input text
-  bool input_text = 1;
-  // Include list of individual generated tokens
-  // "Extra" token information is included based on the other flags below
-  bool generated_tokens = 2;
-  // Include list of input tokens
-  // "Extra" token information is included based on the other flags here,
-  // but only for decoder-only models
-  bool input_tokens = 3;
-  // Include logprob for each returned token
-  // Applicable only if generated_tokens == true and/or input_tokens == true
-  bool token_logprobs = 4;
-  // Include rank of each returned token
-  // Applicable only if generated_tokens == true and/or input_tokens == true
-  bool token_ranks = 5;
-  // Include top n candidate tokens at the position of each returned token
-  // The maximum value permitted is 5, but more may be returned if there is a tie
-  // for nth place.
-  // Applicable only if generated_tokens == true and/or input_tokens == true
-  uint32 top_n_tokens = 6;
-}
-
-enum StopReason {
-  // Possibly more tokens to be streamed
-  NOT_FINISHED = 0;
-  // Maximum requested tokens reached
-  MAX_TOKENS = 1;
-  // End-of-sequence token encountered
-  EOS_TOKEN = 2;
-  // Request cancelled by client
-  CANCELLED = 3;
-  // Time limit reached
-  TIME_LIMIT = 4;
-  // Stop sequence encountered
-  STOP_SEQUENCE = 5;
-  // Total token limit reached
-  TOKEN_LIMIT = 6;
-  // Decoding error
-  ERROR = 7;
-}
-
-message TokenInfo {
-  // uint32 id = 1;  // TBD
-  string text = 2;
-  // The logprob (log of normalized probability), if requested
-  float logprob = 3;
-  // One-based rank relative to other tokens, if requested
-  uint32 rank = 4;
-
-  message TopToken {
-    // uint32 id = 1;  // TBD
-    string text = 2;
-    float logprob = 3;
-  }
-
-  // Top N candidate tokens at this position, if requested
-  // May or may not include this token
-  repeated TopToken top_tokens = 5;
-}
+   // Exponentially increases the score of the EOS token
+   // once start_index tokens have been generated
+   optional LengthPenalty length_penalty = 2;
+ }
 
 
-// ============================================================================================================
-// Tokenization API
+ message SamplingParameters {
+   // Default (0.0) means disabled (equivalent to 1.0)
+   float temperature = 1;
+   // Default (0) means disabled
+   uint32 top_k = 2;
+   // Default (0) means disabled (equivalent to 1.0)
+   float top_p = 3;
+   // Default (0) means disabled (equivalent to 1.0)
+   float typical_p = 4;
 
-message BatchedTokenizeRequest {
-  string model_id = 1;
-  repeated TokenizeRequest requests = 2;
-  bool return_tokens = 3; //TBD
-}
+   optional uint64 seed = 5;
+ }
 
-message BatchedTokenizeResponse {
-  repeated TokenizeResponse responses = 1;
-}
+ message StoppingCriteria {
+   // Default (0) is currently 20
+   uint32 max_new_tokens = 1;
+   // Default (0) means no minimum
+   uint32 min_new_tokens = 2;
+   // Default (0) means no time limit
+   uint32 time_limit_millis = 3;
+   repeated string stop_sequences = 4;
 
-message TokenizeRequest {
-  string text = 1;
-}
+   //more to come
+ }
 
-message TokenizeResponse {
-  uint32 token_count = 1;
-  repeated string tokens = 2; // if include_tokens = true
+ message ResponseOptions {
+   // Include input text
+   bool input_text = 1;
+   // Include list of individual generated tokens
+   // "Extra" token information is included based on the other flags below
+   bool generated_tokens = 2;
+   // Include list of input tokens
+   // "Extra" token information is included based on the other flags here,
+   // but only for decoder-only models
+   bool input_tokens = 3;
+   // Include logprob for each returned token
+   // Applicable only if generated_tokens == true and/or input_tokens == true
+   bool token_logprobs = 4;
+   // Include rank of each returned token
+   // Applicable only if generated_tokens == true and/or input_tokens == true
+   bool token_ranks = 5;
+   // Include top n candidate tokens at the position of each returned token
+   // The maximum value permitted is 5, but more may be returned if there is a tie
+   // for nth place.
+   // Applicable only if generated_tokens == true and/or input_tokens == true
+   uint32 top_n_tokens = 6;
+ }
 
-  // We'll possibly add more later
-}
+ enum StopReason {
+   // Possibly more tokens to be streamed
+   NOT_FINISHED = 0;
+   // Maximum requested tokens reached
+   MAX_TOKENS = 1;
+   // End-of-sequence token encountered
+   EOS_TOKEN = 2;
+   // Request cancelled by client
+   CANCELLED = 3;
+   // Time limit reached
+   TIME_LIMIT = 4;
+   // Stop sequence encountered
+   STOP_SEQUENCE = 5;
+   // Total token limit reached
+   TOKEN_LIMIT = 6;
+   // Decoding error
+   ERROR = 7;
+ }
+
+ message TokenInfo {
+   // uint32 id = 1;  // TBD
+   string text = 2;
+   // The logprob (log of normalized probability), if requested
+   float logprob = 3;
+   // One-based rank relative to other tokens, if requested
+   uint32 rank = 4;
+
+   message TopToken {
+     // uint32 id = 1;  // TBD
+     string text = 2;
+     float logprob = 3;
+   }
+
+   // Top N candidate tokens at this position, if requested
+   // May or may not include this token
+   repeated TopToken top_tokens = 5;
+ }
+
+
+ // ============================================================================================================
+ // Tokenization API
+
+ message BatchedTokenizeRequest {
+   string model_id = 1;
+   repeated TokenizeRequest requests = 2;
+   bool return_tokens = 3; //TBD
+ }
+
+ message BatchedTokenizeResponse {
+   repeated TokenizeResponse responses = 1;
+ }
+
+ message TokenizeRequest {
+   string text = 1;
+ }
+
+ message TokenizeResponse {
+   uint32 token_count = 1;
+   repeated string tokens = 2; // if include_tokens = true
+
+   // We'll possibly add more later
+ }
+
+
+ // ============================================================================================================
+ // Model Info API
+
+ message ModelInfoRequest {
+   string model_id = 1;
+ }
+
+ message ModelInfoResponse {
+   enum ModelKind {
+     DECODER_ONLY = 0;
+     ENCODER_DECODER = 1;
+   }
+
+   ModelKind model_kind = 1;
+   uint32 max_sequence_length = 2;
+   uint32 max_new_tokens = 3;
+ }

--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -116,6 +116,7 @@ class ManagedTGISSubprocess:
         """Get the TGISConnection object for this local connection"""
         return TGISConnection(
             hostname=self._hostname,
+            model_id=self._model_id,
             prompt_dir=self._prompt_dir,
             _client=self.get_client(),
         )

--- a/caikit_tgis_backend/protobufs/generation_pb2.py
+++ b/caikit_tgis_backend/protobufs/generation_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10generation.proto\x12\x05\x66maas\"\xa1\x01\n\x18\x42\x61tchedGenerationRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x16\n\tprefix_id\x18\x02 \x01(\tH\x00\x88\x01\x01\x12*\n\x08requests\x18\x03 \x03(\x0b\x32\x18.fmaas.GenerationRequest\x12!\n\x06params\x18\n \x01(\x0b\x32\x11.fmaas.ParametersB\x0c\n\n_prefix_id\"\x9f\x01\n\x17SingleGenerationRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x16\n\tprefix_id\x18\x02 \x01(\tH\x00\x88\x01\x01\x12)\n\x07request\x18\x03 \x01(\x0b\x32\x18.fmaas.GenerationRequest\x12!\n\x06params\x18\n \x01(\x0b\x32\x11.fmaas.ParametersB\x0c\n\n_prefix_id\"I\n\x19\x42\x61tchedGenerationResponse\x12,\n\tresponses\x18\x01 \x03(\x0b\x32\x19.fmaas.GenerationResponse\"!\n\x11GenerationRequest\x12\x0c\n\x04text\x18\x02 \x01(\t\"\xdc\x01\n\x12GenerationResponse\x12\x19\n\x11input_token_count\x18\x06 \x01(\r\x12\x1d\n\x15generated_token_count\x18\x02 \x01(\r\x12\x0c\n\x04text\x18\x04 \x01(\t\x12&\n\x0bstop_reason\x18\x07 \x01(\x0e\x32\x11.fmaas.StopReason\x12\x0c\n\x04seed\x18\n \x01(\x04\x12 \n\x06tokens\x18\x08 \x03(\x0b\x32\x10.fmaas.TokenInfo\x12&\n\x0cinput_tokens\x18\t \x03(\x0b\x32\x10.fmaas.TokenInfo\"\x81\x02\n\nParameters\x12%\n\x06method\x18\x01 \x01(\x0e\x32\x15.fmaas.DecodingMethod\x12+\n\x08sampling\x18\x02 \x01(\x0b\x32\x19.fmaas.SamplingParameters\x12)\n\x08stopping\x18\x03 \x01(\x0b\x32\x17.fmaas.StoppingCriteria\x12(\n\x08response\x18\x04 \x01(\x0b\x32\x16.fmaas.ResponseOptions\x12+\n\x08\x64\x65\x63oding\x18\x05 \x01(\x0b\x32\x19.fmaas.DecodingParameters\x12\x1d\n\x15truncate_input_tokens\x18\x06 \x01(\r\"\xc5\x01\n\x12\x44\x65\x63odingParameters\x12\x1a\n\x12repetition_penalty\x18\x01 \x01(\x02\x12\x44\n\x0elength_penalty\x18\x02 \x01(\x0b\x32\'.fmaas.DecodingParameters.LengthPenaltyH\x00\x88\x01\x01\x1a:\n\rLengthPenalty\x12\x13\n\x0bstart_index\x18\x01 \x01(\r\x12\x14\n\x0c\x64\x65\x63\x61y_factor\x18\x02 \x01(\x02\x42\x11\n\x0f_length_penalty\"c\n\x12SamplingParameters\x12\x13\n\x0btemperature\x18\x01 \x01(\x02\x12\r\n\x05top_k\x18\x02 \x01(\r\x12\r\n\x05top_p\x18\x03 \x01(\x02\x12\x11\n\x04seed\x18\x05 \x01(\x04H\x00\x88\x01\x01\x42\x07\n\x05_seed\"u\n\x10StoppingCriteria\x12\x16\n\x0emax_new_tokens\x18\x01 \x01(\r\x12\x16\n\x0emin_new_tokens\x18\x02 \x01(\r\x12\x19\n\x11time_limit_millis\x18\x03 \x01(\r\x12\x16\n\x0estop_sequences\x18\x04 \x03(\t\"\x98\x01\n\x0fResponseOptions\x12\x12\n\ninput_text\x18\x01 \x01(\x08\x12\x18\n\x10generated_tokens\x18\x02 \x01(\x08\x12\x14\n\x0cinput_tokens\x18\x03 \x01(\x08\x12\x16\n\x0etoken_logprobs\x18\x04 \x01(\x08\x12\x13\n\x0btoken_ranks\x18\x05 \x01(\x08\x12\x14\n\x0ctop_n_tokens\x18\x06 \x01(\r\"\x92\x01\n\tTokenInfo\x12\x0c\n\x04text\x18\x02 \x01(\t\x12\x0f\n\x07logprob\x18\x03 \x01(\x02\x12\x0c\n\x04rank\x18\x04 \x01(\r\x12-\n\ntop_tokens\x18\x05 \x03(\x0b\x32\x19.fmaas.TokenInfo.TopToken\x1a)\n\x08TopToken\x12\x0c\n\x04text\x18\x02 \x01(\t\x12\x0f\n\x07logprob\x18\x03 \x01(\x02\"k\n\x16\x42\x61tchedTokenizeRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12(\n\x08requests\x18\x02 \x03(\x0b\x32\x16.fmaas.TokenizeRequest\x12\x15\n\rreturn_tokens\x18\x03 \x01(\x08\"E\n\x17\x42\x61tchedTokenizeResponse\x12*\n\tresponses\x18\x01 \x03(\x0b\x32\x17.fmaas.TokenizeResponse\"\x1f\n\x0fTokenizeRequest\x12\x0c\n\x04text\x18\x01 \x01(\t\"7\n\x10TokenizeResponse\x12\x13\n\x0btoken_count\x18\x01 \x01(\r\x12\x0e\n\x06tokens\x18\x02 \x03(\t*(\n\x0e\x44\x65\x63odingMethod\x12\n\n\x06GREEDY\x10\x00\x12\n\n\x06SAMPLE\x10\x01*\x8b\x01\n\nStopReason\x12\x10\n\x0cNOT_FINISHED\x10\x00\x12\x0e\n\nMAX_TOKENS\x10\x01\x12\r\n\tEOS_TOKEN\x10\x02\x12\r\n\tCANCELLED\x10\x03\x12\x0e\n\nTIME_LIMIT\x10\x04\x12\x11\n\rSTOP_SEQUENCE\x10\x05\x12\x0f\n\x0bTOKEN_LIMIT\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x32\x82\x02\n\x11GenerationService\x12O\n\x08Generate\x12\x1f.fmaas.BatchedGenerationRequest\x1a .fmaas.BatchedGenerationResponse\"\x00\x12O\n\x0eGenerateStream\x12\x1e.fmaas.SingleGenerationRequest\x1a\x19.fmaas.GenerationResponse\"\x00\x30\x01\x12K\n\x08Tokenize\x12\x1d.fmaas.BatchedTokenizeRequest\x1a\x1e.fmaas.BatchedTokenizeResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10generation.proto\x12\x05\x66maas\"\xa1\x01\n\x18\x42\x61tchedGenerationRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x16\n\tprefix_id\x18\x02 \x01(\tH\x00\x88\x01\x01\x12*\n\x08requests\x18\x03 \x03(\x0b\x32\x18.fmaas.GenerationRequest\x12!\n\x06params\x18\n \x01(\x0b\x32\x11.fmaas.ParametersB\x0c\n\n_prefix_id\"\x9f\x01\n\x17SingleGenerationRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x16\n\tprefix_id\x18\x02 \x01(\tH\x00\x88\x01\x01\x12)\n\x07request\x18\x03 \x01(\x0b\x32\x18.fmaas.GenerationRequest\x12!\n\x06params\x18\n \x01(\x0b\x32\x11.fmaas.ParametersB\x0c\n\n_prefix_id\"I\n\x19\x42\x61tchedGenerationResponse\x12,\n\tresponses\x18\x01 \x03(\x0b\x32\x19.fmaas.GenerationResponse\"!\n\x11GenerationRequest\x12\x0c\n\x04text\x18\x02 \x01(\t\"\xdc\x01\n\x12GenerationResponse\x12\x19\n\x11input_token_count\x18\x06 \x01(\r\x12\x1d\n\x15generated_token_count\x18\x02 \x01(\r\x12\x0c\n\x04text\x18\x04 \x01(\t\x12&\n\x0bstop_reason\x18\x07 \x01(\x0e\x32\x11.fmaas.StopReason\x12\x0c\n\x04seed\x18\n \x01(\x04\x12 \n\x06tokens\x18\x08 \x03(\x0b\x32\x10.fmaas.TokenInfo\x12&\n\x0cinput_tokens\x18\t \x03(\x0b\x32\x10.fmaas.TokenInfo\"\x81\x02\n\nParameters\x12%\n\x06method\x18\x01 \x01(\x0e\x32\x15.fmaas.DecodingMethod\x12+\n\x08sampling\x18\x02 \x01(\x0b\x32\x19.fmaas.SamplingParameters\x12)\n\x08stopping\x18\x03 \x01(\x0b\x32\x17.fmaas.StoppingCriteria\x12(\n\x08response\x18\x04 \x01(\x0b\x32\x16.fmaas.ResponseOptions\x12+\n\x08\x64\x65\x63oding\x18\x05 \x01(\x0b\x32\x19.fmaas.DecodingParameters\x12\x1d\n\x15truncate_input_tokens\x18\x06 \x01(\r\"\xc5\x01\n\x12\x44\x65\x63odingParameters\x12\x1a\n\x12repetition_penalty\x18\x01 \x01(\x02\x12\x44\n\x0elength_penalty\x18\x02 \x01(\x0b\x32\'.fmaas.DecodingParameters.LengthPenaltyH\x00\x88\x01\x01\x1a:\n\rLengthPenalty\x12\x13\n\x0bstart_index\x18\x01 \x01(\r\x12\x14\n\x0c\x64\x65\x63\x61y_factor\x18\x02 \x01(\x02\x42\x11\n\x0f_length_penalty\"v\n\x12SamplingParameters\x12\x13\n\x0btemperature\x18\x01 \x01(\x02\x12\r\n\x05top_k\x18\x02 \x01(\r\x12\r\n\x05top_p\x18\x03 \x01(\x02\x12\x11\n\ttypical_p\x18\x04 \x01(\x02\x12\x11\n\x04seed\x18\x05 \x01(\x04H\x00\x88\x01\x01\x42\x07\n\x05_seed\"u\n\x10StoppingCriteria\x12\x16\n\x0emax_new_tokens\x18\x01 \x01(\r\x12\x16\n\x0emin_new_tokens\x18\x02 \x01(\r\x12\x19\n\x11time_limit_millis\x18\x03 \x01(\r\x12\x16\n\x0estop_sequences\x18\x04 \x03(\t\"\x98\x01\n\x0fResponseOptions\x12\x12\n\ninput_text\x18\x01 \x01(\x08\x12\x18\n\x10generated_tokens\x18\x02 \x01(\x08\x12\x14\n\x0cinput_tokens\x18\x03 \x01(\x08\x12\x16\n\x0etoken_logprobs\x18\x04 \x01(\x08\x12\x13\n\x0btoken_ranks\x18\x05 \x01(\x08\x12\x14\n\x0ctop_n_tokens\x18\x06 \x01(\r\"\x92\x01\n\tTokenInfo\x12\x0c\n\x04text\x18\x02 \x01(\t\x12\x0f\n\x07logprob\x18\x03 \x01(\x02\x12\x0c\n\x04rank\x18\x04 \x01(\r\x12-\n\ntop_tokens\x18\x05 \x03(\x0b\x32\x19.fmaas.TokenInfo.TopToken\x1a)\n\x08TopToken\x12\x0c\n\x04text\x18\x02 \x01(\t\x12\x0f\n\x07logprob\x18\x03 \x01(\x02\"k\n\x16\x42\x61tchedTokenizeRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12(\n\x08requests\x18\x02 \x03(\x0b\x32\x16.fmaas.TokenizeRequest\x12\x15\n\rreturn_tokens\x18\x03 \x01(\x08\"E\n\x17\x42\x61tchedTokenizeResponse\x12*\n\tresponses\x18\x01 \x03(\x0b\x32\x17.fmaas.TokenizeResponse\"\x1f\n\x0fTokenizeRequest\x12\x0c\n\x04text\x18\x01 \x01(\t\"7\n\x10TokenizeResponse\x12\x13\n\x0btoken_count\x18\x01 \x01(\r\x12\x0e\n\x06tokens\x18\x02 \x03(\t\"$\n\x10ModelInfoRequest\x12\x10\n\x08model_id\x18\x01 \x01(\t\"\xb4\x01\n\x11ModelInfoResponse\x12\x36\n\nmodel_kind\x18\x01 \x01(\x0e\x32\".fmaas.ModelInfoResponse.ModelKind\x12\x1b\n\x13max_sequence_length\x18\x02 \x01(\r\x12\x16\n\x0emax_new_tokens\x18\x03 \x01(\r\"2\n\tModelKind\x12\x10\n\x0c\x44\x45\x43ODER_ONLY\x10\x00\x12\x13\n\x0f\x45NCODER_DECODER\x10\x01*(\n\x0e\x44\x65\x63odingMethod\x12\n\n\x06GREEDY\x10\x00\x12\n\n\x06SAMPLE\x10\x01*\x8b\x01\n\nStopReason\x12\x10\n\x0cNOT_FINISHED\x10\x00\x12\x0e\n\nMAX_TOKENS\x10\x01\x12\r\n\tEOS_TOKEN\x10\x02\x12\r\n\tCANCELLED\x10\x03\x12\x0e\n\nTIME_LIMIT\x10\x04\x12\x11\n\rSTOP_SEQUENCE\x10\x05\x12\x0f\n\x0bTOKEN_LIMIT\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x32\xc4\x02\n\x11GenerationService\x12O\n\x08Generate\x12\x1f.fmaas.BatchedGenerationRequest\x1a .fmaas.BatchedGenerationResponse\"\x00\x12O\n\x0eGenerateStream\x12\x1e.fmaas.SingleGenerationRequest\x1a\x19.fmaas.GenerationResponse\"\x00\x30\x01\x12K\n\x08Tokenize\x12\x1d.fmaas.BatchedTokenizeRequest\x1a\x1e.fmaas.BatchedTokenizeResponse\"\x00\x12@\n\tModelInfo\x12\x17.fmaas.ModelInfoRequest\x1a\x18.fmaas.ModelInfoResponse\"\x00\x62\x06proto3')
 
 _DECODINGMETHOD = DESCRIPTOR.enum_types_by_name['DecodingMethod']
 DecodingMethod = enum_type_wrapper.EnumTypeWrapper(_DECODINGMETHOD)
@@ -50,6 +50,9 @@ _BATCHEDTOKENIZEREQUEST = DESCRIPTOR.message_types_by_name['BatchedTokenizeReque
 _BATCHEDTOKENIZERESPONSE = DESCRIPTOR.message_types_by_name['BatchedTokenizeResponse']
 _TOKENIZEREQUEST = DESCRIPTOR.message_types_by_name['TokenizeRequest']
 _TOKENIZERESPONSE = DESCRIPTOR.message_types_by_name['TokenizeResponse']
+_MODELINFOREQUEST = DESCRIPTOR.message_types_by_name['ModelInfoRequest']
+_MODELINFORESPONSE = DESCRIPTOR.message_types_by_name['ModelInfoResponse']
+_MODELINFORESPONSE_MODELKIND = _MODELINFORESPONSE.enum_types_by_name['ModelKind']
 BatchedGenerationRequest = _reflection.GeneratedProtocolMessageType('BatchedGenerationRequest', (_message.Message,), {
   'DESCRIPTOR' : _BATCHEDGENERATIONREQUEST,
   '__module__' : 'generation_pb2'
@@ -171,14 +174,28 @@ TokenizeResponse = _reflection.GeneratedProtocolMessageType('TokenizeResponse', 
   })
 _sym_db.RegisterMessage(TokenizeResponse)
 
+ModelInfoRequest = _reflection.GeneratedProtocolMessageType('ModelInfoRequest', (_message.Message,), {
+  'DESCRIPTOR' : _MODELINFOREQUEST,
+  '__module__' : 'generation_pb2'
+  # @@protoc_insertion_point(class_scope:fmaas.ModelInfoRequest)
+  })
+_sym_db.RegisterMessage(ModelInfoRequest)
+
+ModelInfoResponse = _reflection.GeneratedProtocolMessageType('ModelInfoResponse', (_message.Message,), {
+  'DESCRIPTOR' : _MODELINFORESPONSE,
+  '__module__' : 'generation_pb2'
+  # @@protoc_insertion_point(class_scope:fmaas.ModelInfoResponse)
+  })
+_sym_db.RegisterMessage(ModelInfoResponse)
+
 _GENERATIONSERVICE = DESCRIPTOR.services_by_name['GenerationService']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _DECODINGMETHOD._serialized_start=1940
-  _DECODINGMETHOD._serialized_end=1980
-  _STOPREASON._serialized_start=1983
-  _STOPREASON._serialized_end=2122
+  _DECODINGMETHOD._serialized_start=2180
+  _DECODINGMETHOD._serialized_end=2220
+  _STOPREASON._serialized_start=2223
+  _STOPREASON._serialized_end=2362
   _BATCHEDGENERATIONREQUEST._serialized_start=28
   _BATCHEDGENERATIONREQUEST._serialized_end=189
   _SINGLEGENERATIONREQUEST._serialized_start=192
@@ -196,23 +213,29 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _DECODINGPARAMETERS_LENGTHPENALTY._serialized_start=1067
   _DECODINGPARAMETERS_LENGTHPENALTY._serialized_end=1125
   _SAMPLINGPARAMETERS._serialized_start=1146
-  _SAMPLINGPARAMETERS._serialized_end=1245
-  _STOPPINGCRITERIA._serialized_start=1247
-  _STOPPINGCRITERIA._serialized_end=1364
-  _RESPONSEOPTIONS._serialized_start=1367
-  _RESPONSEOPTIONS._serialized_end=1519
-  _TOKENINFO._serialized_start=1522
-  _TOKENINFO._serialized_end=1668
-  _TOKENINFO_TOPTOKEN._serialized_start=1627
-  _TOKENINFO_TOPTOKEN._serialized_end=1668
-  _BATCHEDTOKENIZEREQUEST._serialized_start=1670
-  _BATCHEDTOKENIZEREQUEST._serialized_end=1777
-  _BATCHEDTOKENIZERESPONSE._serialized_start=1779
-  _BATCHEDTOKENIZERESPONSE._serialized_end=1848
-  _TOKENIZEREQUEST._serialized_start=1850
-  _TOKENIZEREQUEST._serialized_end=1881
-  _TOKENIZERESPONSE._serialized_start=1883
-  _TOKENIZERESPONSE._serialized_end=1938
-  _GENERATIONSERVICE._serialized_start=2125
-  _GENERATIONSERVICE._serialized_end=2383
+  _SAMPLINGPARAMETERS._serialized_end=1264
+  _STOPPINGCRITERIA._serialized_start=1266
+  _STOPPINGCRITERIA._serialized_end=1383
+  _RESPONSEOPTIONS._serialized_start=1386
+  _RESPONSEOPTIONS._serialized_end=1538
+  _TOKENINFO._serialized_start=1541
+  _TOKENINFO._serialized_end=1687
+  _TOKENINFO_TOPTOKEN._serialized_start=1646
+  _TOKENINFO_TOPTOKEN._serialized_end=1687
+  _BATCHEDTOKENIZEREQUEST._serialized_start=1689
+  _BATCHEDTOKENIZEREQUEST._serialized_end=1796
+  _BATCHEDTOKENIZERESPONSE._serialized_start=1798
+  _BATCHEDTOKENIZERESPONSE._serialized_end=1867
+  _TOKENIZEREQUEST._serialized_start=1869
+  _TOKENIZEREQUEST._serialized_end=1900
+  _TOKENIZERESPONSE._serialized_start=1902
+  _TOKENIZERESPONSE._serialized_end=1957
+  _MODELINFOREQUEST._serialized_start=1959
+  _MODELINFOREQUEST._serialized_end=1995
+  _MODELINFORESPONSE._serialized_start=1998
+  _MODELINFORESPONSE._serialized_end=2178
+  _MODELINFORESPONSE_MODELKIND._serialized_start=2128
+  _MODELINFORESPONSE_MODELKIND._serialized_end=2178
+  _GENERATIONSERVICE._serialized_start=2365
+  _GENERATIONSERVICE._serialized_end=2689
 # @@protoc_insertion_point(module_scope)

--- a/caikit_tgis_backend/protobufs/generation_pb2_grpc.py
+++ b/caikit_tgis_backend/protobufs/generation_pb2_grpc.py
@@ -29,6 +29,11 @@ class GenerationServiceStub(object):
                 request_serializer=generation__pb2.BatchedTokenizeRequest.SerializeToString,
                 response_deserializer=generation__pb2.BatchedTokenizeResponse.FromString,
                 )
+        self.ModelInfo = channel.unary_unary(
+                '/fmaas.GenerationService/ModelInfo',
+                request_serializer=generation__pb2.ModelInfoRequest.SerializeToString,
+                response_deserializer=generation__pb2.ModelInfoResponse.FromString,
+                )
 
 
 class GenerationServiceServicer(object):
@@ -55,6 +60,13 @@ class GenerationServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def ModelInfo(self, request, context):
+        """Model info
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_GenerationServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -72,6 +84,11 @@ def add_GenerationServiceServicer_to_server(servicer, server):
                     servicer.Tokenize,
                     request_deserializer=generation__pb2.BatchedTokenizeRequest.FromString,
                     response_serializer=generation__pb2.BatchedTokenizeResponse.SerializeToString,
+            ),
+            'ModelInfo': grpc.unary_unary_rpc_method_handler(
+                    servicer.ModelInfo,
+                    request_deserializer=generation__pb2.ModelInfoRequest.FromString,
+                    response_serializer=generation__pb2.ModelInfoResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -131,5 +148,22 @@ class GenerationService(object):
         return grpc.experimental.unary_unary(request, target, '/fmaas.GenerationService/Tokenize',
             generation__pb2.BatchedTokenizeRequest.SerializeToString,
             generation__pb2.BatchedTokenizeResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ModelInfo(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/fmaas.GenerationService/ModelInfo',
+            generation__pb2.ModelInfoRequest.SerializeToString,
+            generation__pb2.ModelInfoResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -18,6 +18,9 @@
 from threading import Lock
 from typing import Dict, Optional
 
+# Third Party
+import grpc
+
 # First Party
 from caikit.core.module_backends.backend_types import register_backend_type
 from caikit.core.module_backends.base import BackendBase
@@ -38,8 +41,9 @@ class TGISBackend(BackendBase):
     details are given, this backend will manage an instance of the TGIS as a
     subprocess for the lifecycle of the model that needs it.
 
-    NOTE: Currently TGIS does not support multiple models, so calls to get a
-        client for a model _other_ than the first one will fail!
+    NOTE: Currently TGIS does not support multiple models, so when running TGIS
+        locally, calls to get a client for a model _other_ than the first one
+        will fail!
 
     TODO: To handle multi-model TGIS, we can maintain an independent process for
         each model. To do this, we'd need to dynamically generate the port and
@@ -64,6 +68,7 @@ class TGISBackend(BackendBase):
         self._local_tgis = None
         self._managed_tgis = None
         self._model_connections = {}
+        self._test_connections = self.config.get("test_connections", False)
 
         # Parse the config to see if we're managing a connection to a remote
         # TGIS instance or running a local copy
@@ -101,7 +106,20 @@ class TGISBackend(BackendBase):
                 "Invalid connection config for {}",
                 model_id,
             )
-            self._model_connections[model_id] = model_conn
+            if self._test_connections:
+                try:
+                    model_conn.test_connection()
+                except grpc.RpcError as err:
+                    log.warning(
+                        "<TGB95244222W>",
+                        "Unable to connect to model %s: %s",
+                        model_id,
+                        err,
+                        exc_info=True,
+                    )
+                    model_conn = None
+            if model_conn is not None:
+                self._model_connections[model_id] = model_conn
 
         # We manage a local TGIS instance if there are no remote connections
         # specified as either a valid base connection or remote_connections
@@ -160,10 +178,23 @@ class TGISBackend(BackendBase):
             and self._base_connection_cfg
         ):
             with self._mutex:
-                model_conn = self._model_connections.setdefault(
-                    model_id,
-                    TGISConnection.from_config(model_id, self._base_connection_cfg),
+                model_conn = TGISConnection.from_config(
+                    model_id, self._base_connection_cfg
                 )
+                if self._test_connections:
+                    try:
+                        model_conn.test_connection()
+                    except grpc.RpcError as err:
+                        log.warning(
+                            "<TGB50048960W>",
+                            "Unable to connect to model %s: %s",
+                            model_id,
+                            err,
+                            exc_info=True,
+                        )
+                        model_conn = None
+                if model_conn is not None:
+                    self._model_connections.setdefault(model_id, model_conn)
         return model_conn
 
     def get_client(self, model_id: str) -> generation_pb2_grpc.GenerationServiceStub:

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -27,7 +27,7 @@ from caikit.core.toolkit.errors import error_handler
 import alog
 
 # Local
-from .protobufs import generation_pb2_grpc
+from .protobufs import generation_pb2, generation_pb2_grpc
 
 log = alog.use_channel("TGCONN")
 error = error_handler.get(log)
@@ -219,6 +219,13 @@ class TGISConnection:
                 channel = grpc.secure_channel(self.hostname, credentials=credentials)
             self._client = generation_pb2_grpc.GenerationServiceStub(channel)
         return self._client
+
+    def test_connection(self):
+        """Test whether the connection is valid. If not valid, an appropriate
+        grpc.RpcError will be raised
+        """
+        client = self.get_client()
+        client.ModelInfo(generation_pb2.ModelInfoRequest())
 
     @staticmethod
     def _load_tls_file(file_path: Optional[str]) -> Optional[bytes]:

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -48,6 +48,8 @@ class TGISConnection:
 
     # The URL (with port) for the connection
     hostname: str
+    # The model_id associated with this connection
+    model_id: str
     # Path to CA cert when TGIS is running with TLS
     ca_cert_file: Optional[str] = None
     # Paths to client key/cert pair when TGIS requires mTLS
@@ -147,6 +149,7 @@ class TGISConnection:
             )
             return cls(
                 hostname=hostname,
+                model_id=model_id,
                 ca_cert_file=ca_cert,
                 client_tls=client_tls,
                 prompt_dir=prompt_dir,
@@ -225,7 +228,7 @@ class TGISConnection:
         grpc.RpcError will be raised
         """
         client = self.get_client()
-        client.ModelInfo(generation_pb2.ModelInfoRequest())
+        client.ModelInfo(generation_pb2.ModelInfoRequest(model_id=self.model_id))
 
     @staticmethod
     def _load_tls_file(file_path: Optional[str]) -> Optional[bytes]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit>=0.2.0,<0.15.0", # Core abstractions
+    "caikit>=0.2.0,<0.16.0", # Core abstractions
     "grpcio>=1.35.0,<2.0", # Client calls to TGIS
     "requests>=2.28.2,<3", # Health check calls to TGIS
 ]

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -678,3 +678,26 @@ def test_invalid_connection(params):
     conn, error_type = params
     with pytest.raises(error_type):
         TGISBackend({"connection": conn})
+
+
+def test_tgis_backend_conn_testing_enabled(tgis_mock_insecure):
+    """Make sure that the TGIS backend can be configured with a valid config
+    blob for an insecure server and connection testing enabled
+    """
+    tgis_be = TGISBackend(
+        {
+            "connection": {"hostname": tgis_mock_insecure.hostname},
+            "test_connections": True,
+        }
+    )
+    model_id = "test-model"
+    tgis_be.get_client(model_id).Generate(
+        generation_pb2.BatchedGenerationRequest(
+            requests=[
+                generation_pb2.GenerationRequest(text="Hello world"),
+            ],
+        ),
+    )
+    assert tgis_be.is_started
+    conn = tgis_be.get_connection(model_id)
+    conn.test_connection()

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -20,10 +20,13 @@ import os
 import tempfile
 
 # Third Party
+import grpc
 import pytest
+import tls_test_tools
 
 # Local
 from caikit_tgis_backend.tgis_connection import TGISConnection
+from tests.tgis_mock import tgis_mock_insecure
 
 
 @contextmanager
@@ -179,6 +182,20 @@ def test_load_prompt_artifacts_no_prompt_dir():
         prompt_id = "some-prompt-id"
         with pytest.raises(ValueError):
             conn.load_prompt_artifacts(prompt_id, *source_files)
+
+
+def test_connection_valid_endpoint(tgis_mock_insecure):
+    """Make sure that a connection test works with a valid server"""
+    conn = TGISConnection(hostname=tgis_mock_insecure.hostname)
+    conn.test_connection()
+
+
+def test_connection_invalid_endpoint():
+    """Make sure that a connection test works with a valid server"""
+    hostname = f"localhost:{tls_test_tools.open_port()}"
+    conn = TGISConnection(hostname=hostname)
+    with pytest.raises(grpc.RpcError):
+        conn.test_connection()
 
 
 # NOTE: All failure cases are exercised by test_invalid_connection in

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -186,14 +186,14 @@ def test_load_prompt_artifacts_no_prompt_dir():
 
 def test_connection_valid_endpoint(tgis_mock_insecure):
     """Make sure that a connection test works with a valid server"""
-    conn = TGISConnection(hostname=tgis_mock_insecure.hostname)
+    conn = TGISConnection(hostname=tgis_mock_insecure.hostname, model_id="asdf")
     conn.test_connection()
 
 
 def test_connection_invalid_endpoint():
     """Make sure that a connection test works with a valid server"""
     hostname = f"localhost:{tls_test_tools.open_port()}"
-    conn = TGISConnection(hostname=hostname)
+    conn = TGISConnection(hostname=hostname, model_id="foobar")
     with pytest.raises(grpc.RpcError):
         conn.test_connection()
 

--- a/tests/tgis_mock.py
+++ b/tests/tgis_mock.py
@@ -90,6 +90,9 @@ class TGISMockServicer(generation_pb2_grpc.GenerationServiceServicer):
             responses=[self._gen_resp(req.text) for req in request.requests],
         )
 
+    def ModelInfo(self, request, context):
+        return generation_pb2.ModelInfoResponse()
+
     def _gen_resp(self, request_text: str) -> generation_pb2.GenerationResponse:
         """Generate a single response"""
 


### PR DESCRIPTION
## Description

This PR adds the ability to automatically check a new `TGISConnection` by making a `ModelInfo` request. Further, the connection test can be enabled for all connections managed by a given backend instance by setting `test_connections: true` in the config.