### PR TITLE
:bug: add backend purge

### DIFF
--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -244,6 +244,14 @@ class TGISBackend(BackendBase):
         )
         conn.load_prompt_artifacts(prompt_id, *prompt_artifacts)
 
+    def unload_prompt_artifacts(self, model_id: str, *prompt_ids: str):
+        """Unload all the artifacts for the prompt ids provided with base model model_id"""
+        conn = self.get_connection(model_id)
+        error.value_check(
+            "<TGB99822514E>", conn is not None, "Unknown model {}", model_id
+        )
+        conn.unload_prompt_artifacts(*prompt_ids)
+
     @property
     def local_tgis(self) -> bool:
         return self._local_tgis

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -223,7 +223,7 @@ class TGISConnection:
             log.debug3("Copying %s -> %s", artifact_path, target_file)
             shutil.copyfile(artifact_path, target_file)
 
-    def unload_prompt_artifacts(self, *prompt_ids: List[str]):
+    def unload_prompt_artifacts(self, *prompt_ids: str):
         """Unload the given prompts from TGIS
 
         As implemented, this simply removes the prompt artifacts for these IDs
@@ -235,7 +235,7 @@ class TGISConnection:
             accept that it's already deleted.
 
         Args:
-            *prompt_ids (List[str]): The IDs to unload
+            *prompt_ids (str): The IDs to unload
         """
         error.value_check(
             "<TGB07970365E>",

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -578,6 +578,21 @@ def test_tgis_backend_config_load_prompt_artifacts():
                 os.path.join(bar_prompt_dir, prompt_id2, source_fnames[1])
             )
 
+            # piggy-back to test unloading prompt artifacts
+            tgis_be.unload_prompt_artifacts("bar", prompt_id1, prompt_id2)
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert os.path.exists(
+                os.path.join(foo_prompt_dir, prompt_id2, source_fnames[1])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id1, source_fnames[0])
+            )
+            assert not os.path.exists(
+                os.path.join(bar_prompt_dir, prompt_id2, source_fnames[1])
+            )
+
             # Make sure non-prompt models raise
             with pytest.raises(ValueError):
                 tgis_be.load_prompt_artifacts("baz", prompt_id1, source_files[0])


### PR DESCRIPTION
This adds the missing backend method "unload_prompt_artifacts" to match "load_prompt_artifacts"