### PR TITLE
Do not overwrite prompt artifacts

### DIFF
--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -17,7 +17,7 @@
 from collections.abc import Container
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TypeAlias, Union
+from typing import Optional, Union
 import os
 import shutil
 
@@ -35,7 +35,7 @@ from .protobufs import generation_pb2, generation_pb2_grpc
 log = alog.use_channel("TGCONN")
 error = error_handler.get(log)
 
-StrPath: TypeAlias = Union[str, os.PathLike[str]]
+StrPath = Union[str, os.PathLike[str]]
 
 
 @dataclass

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -17,7 +17,7 @@
 from collections.abc import Container
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional
 import os
 import shutil
 
@@ -32,10 +32,12 @@ import alog
 from .load_balancing_proxy import GRPCLoadBalancerProxy
 from .protobufs import generation_pb2, generation_pb2_grpc
 
+if TYPE_CHECKING:
+    # Third Party
+    from _typeshed import StrPath
+
 log = alog.use_channel("TGCONN")
 error = error_handler.get(log)
-
-StrPath = Union[str, os.PathLike[str]]
 
 
 @dataclass
@@ -367,7 +369,7 @@ class TGISConnection:
 
 
 def file_or_swp_not_in_listing(
-    filename: StrPath, file_listing: Container[str], swap_extension: str = ".swp"
+    filename: "StrPath", file_listing: Container[str], swap_extension: str = ".swp"
 ) -> bool:
     """Determine if the file, or its swap variant, is in the file listing."""
     file = Path(filename)

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -224,15 +224,16 @@ class TGISConnection:
             str,
             artifact_paths=artifact_paths,
         )
+
         target_dir = Path(self.prompt_dir) / prompt_id
         os.makedirs(target_dir, exist_ok=True)
 
         # Don't copy files which are already in the target_dir
-        existing_artifacts = {f.name for f in target_dir.iterdir()}
+        existing_artifact_names = {f.name for f in target_dir.iterdir()}
         new_artifacts = {
             Path(f)
             for f in artifact_paths
-            if file_or_swp_not_in_listing(Path(f).name, existing_artifacts)
+            if file_or_swp_not_in_listing(Path(f).name, existing_artifact_names)
         }
 
         for artifact_path in new_artifacts:

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Encapsulate the creation of a TGIS Connection"""
 
+# Future
+from __future__ import annotations
+
 # Standard
 from collections.abc import Container
 from dataclasses import dataclass

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -245,8 +245,9 @@ class TGISConnection:
             log.debug3("Copying %s -> %s", artifact_path, target_file)
             shutil.copyfile(artifact_path, swp_file)
 
-            # Rename on completion of copy
-            os.rename(swp_file, target_file)
+            # Rename on completion of copy using replace
+            # Replace silently overrides the destination irrespective of OS
+            os.replace(swp_file, target_file)
 
     def unload_prompt_artifacts(self, *prompt_ids: str):
         """Unload the given prompts from TGIS


### PR DESCRIPTION
Issue: caikit/caikit-tgis-backend#51

Updates `load_prompt_artifacts()` to only copy new artifacts.
New artifacts are those which themselves (eg. `foo.pt`) or their swap/in-progress variant (`eg. foo.pt.swp`) already exist in the `prompt_dir` location.

Copying is done in two stages:
1. Copy file with the `.swp` extension appended to indicate a copy is in progress
2. Rename the file by removing the `.swp` extension after the copy is completed