### PR TITLE
Add `TGISBackend.register_model_connection()` method

### DIFF
--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -200,8 +200,6 @@ class TGISBackend(BackendBase):
     def register_model_connection(
         self, model_id: str, conn_cfg: Dict[str, Any]
     ) -> None:
-        # TODO: Is this method necessary? .get_client() -> .get_connection() which will create
-        # the connection in self._model_connections if it doesn't exist by default.
         model_conn = TGISConnection.from_config(model_id, conn_cfg)
         error.value_check("<TGB81270235E>", model_conn is not None)
 
@@ -223,6 +221,7 @@ class TGISBackend(BackendBase):
             #   threads would stimulate the creation of the connection
             #   concurrently, so just keep whichever dict update lands first
             self._model_connections.setdefault(model_id, model_conn)
+            self._remote_models_cfg.setdefault(model_id, conn_cfg)
 
     def get_client(self, model_id: str) -> generation_pb2_grpc.GenerationServiceStub:
         model_conn = self.get_connection(model_id)

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -200,6 +200,8 @@ class TGISBackend(BackendBase):
     def register_model_connection(
         self, model_id: str, conn_cfg: dict[str, Any]
     ) -> None:
+        # TODO: Is this method necessary? .get_client() -> .get_connection() which will create
+        # the connection in self._model_connections if it doesn't exist by default.
         model_conn = TGISConnection.from_config(model_id, conn_cfg)
         error.value_check("<TGB81270235E>", model_conn is not None)
 

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -14,6 +14,7 @@
 """This module implements a TGIS backend configuration"""
 
 # Standard
+from copy import deepcopy
 from threading import Lock
 from typing import Any, Dict, Optional
 
@@ -197,10 +198,10 @@ class TGISBackend(BackendBase):
         # Craft new connection config
         new_conn_cfg = {}
         if conn_cfg is None:
-            new_conn_cfg = self._base_connection_cfg
+            new_conn_cfg = deepcopy(self._base_connection_cfg)
         else:
             if fill_with_defaults:
-                new_conn_cfg = self._base_connection_cfg
+                new_conn_cfg = deepcopy(self._base_connection_cfg)
             new_conn_cfg.update(conn_cfg)
 
         # Create model connection

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -67,7 +67,7 @@ class TGISBackend(BackendBase):
         self._mutex = Lock()
         self._local_tgis = None
         self._managed_tgis = None
-        self._model_connections: dict[str, TGISConnection] = {}
+        self._model_connections: Dict[str, TGISConnection] = {}
         self._test_connections = self.config.get("test_connections", False)
         self._connect_timeout = self.config.get("connect_timeout", None)
 
@@ -75,7 +75,7 @@ class TGISBackend(BackendBase):
         # TGIS instance or running a local copy
         connection_cfg = self.config.get("connection") or {}
         error.type_check("<TGB20235229E>", dict, connection=connection_cfg)
-        self._remote_models_cfg: dict[str, dict] = (
+        self._remote_models_cfg: Dict[str, dict] = (
             self.config.get("remote_models") or {}
         )
         error.type_check("<TGB20235338E>", dict, connection=self._remote_models_cfg)
@@ -198,7 +198,7 @@ class TGISBackend(BackendBase):
         return model_conn
 
     def register_model_connection(
-        self, model_id: str, conn_cfg: dict[str, Any]
+        self, model_id: str, conn_cfg: Dict[str, Any]
     ) -> None:
         # TODO: Is this method necessary? .get_client() -> .get_connection() which will create
         # the connection in self._model_connections if it doesn't exist by default.

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -198,9 +198,27 @@ class TGISBackend(BackendBase):
         return model_conn
 
     def register_model_connection(
-        self, model_id: str, conn_cfg: Dict[str, Any]
+        self,
+        model_id: str,
+        conn_cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
-        model_conn = TGISConnection.from_config(model_id, conn_cfg)
+        """
+        Register a remote model connection.
+
+        If the model connection is already registered, do nothing.
+
+        Otherwise create and register the model connection using the TGISBackend's config connection,
+        or the `conn_cfg` if provided.
+        """
+        if model_id in self._model_connections:
+            # Model connection exists --> do nothing
+            return
+
+        # Create model connection...
+        if conn_cfg is None:
+            model_conn = TGISConnection.from_config(model_id, self._base_connection_cfg)
+        else:
+            model_conn = TGISConnection.from_config(model_id, conn_cfg)
         error.value_check("<TGB81270235E>", model_conn is not None)
 
         if self._test_connections:

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -312,7 +312,8 @@ class TGISBackend(BackendBase):
         remote_models_cfg: Optional[Dict[str, Any]] = None,
     ):
         """
-        Update the `_model_connections` and `_remote_models_cfg` state dictionaries in a thread safe manner
+        Update the `_model_connections` and `_remote_models_cfg` state dictionaries in a
+        thread safe manner.
         """
         # NOTE: setdefault used here to avoid the need to hold the mutex
         #   when running the connection test. It's possible that two

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -207,8 +207,8 @@ class TGISBackend(BackendBase):
 
         If the model connection is already registered, do nothing.
 
-        Otherwise create and register the model connection using the TGISBackend's config connection,
-        or the `conn_cfg` if provided.
+        Otherwise create and register the model connection using the TGISBackend's
+        config connection, or the `conn_cfg` if provided.
         """
         if model_id in self._model_connections:
             # Model connection exists --> do nothing

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Container
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 import os
 import shutil
 

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -96,7 +96,7 @@ class TGISConnection:
         """Create an instance from a connection template and a model_id"""
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:
-            assert isinstance(hostname, str)
+            error.type_check("<TGB57775870E>", str, hostname=hostname)
 
             hostname = hostname.format_map(
                 {

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -92,7 +92,9 @@ class TGISConnection:
     TLS_HN_OVERRIDE_KEY = "hostname_override"
 
     @classmethod
-    def from_config(cls, model_id: str, config: dict) -> Optional["TGISConnection"]:
+    def from_config(
+        cls, model_id: str, config: Dict[str, Any]
+    ) -> Optional["TGISConnection"]:
         """Create an instance from a connection template and a model_id"""
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -97,7 +97,6 @@ class TGISConnection:
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:
             assert isinstance(hostname, str)
-            # TODO: Namespace needs to be populated here as well into the hostname template
             namespace = config.get(cls.NAMESPACE_KEY)
 
             hostname = hostname.format_map(
@@ -114,7 +113,6 @@ class TGISConnection:
             )
 
             tls_hostname_override = config.get(cls.TLS_HN_OVERRIDE_KEY)
-
             lb_policy = config.get(cls.LB_POLICY_KEY) or None
             error.type_check(
                 "<TGB17223790E>",

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -81,7 +81,8 @@ class TGISConnection:
 
     HOSTNAME_KEY = "hostname"
     HOSTNAME_TEMPLATE_MODEL_ID = "model_id"
-    # TODO: Add key for namespace here
+    NAMESPACE_KEY = "namespace"
+    HOSTNAME_TEMPLATE_NAMESPACE = "namespace"
     CA_CERT_FILE_KEY = "ca_cert_file"
     CLIENT_CERT_FILE_KEY = "client_cert_file"
     CLIENT_KEY_FILE_KEY = "client_key_file"
@@ -95,13 +96,22 @@ class TGISConnection:
         """Create an instance from a connection template and a model_id"""
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:
+            assert isinstance(hostname, str)
             # TODO: Namespace needs to be populated here as well into the hostname template
-            hostname = hostname.format(
-                **{
+            namespace = config.get(cls.NAMESPACE_KEY)
+
+            hostname = hostname.format_map(
+                {
                     cls.HOSTNAME_TEMPLATE_MODEL_ID: model_id,
+                    cls.HOSTNAME_TEMPLATE_NAMESPACE: namespace,
                 }
             )
-            log.debug("Resolved hostname [%s] for model %s", hostname, model_id)
+            log.debug(
+                "Resolved hostname [%s] for model %s in namespace %s",
+                hostname,
+                model_id,
+                namespace,
+            )
 
             tls_hostname_override = config.get(cls.TLS_HN_OVERRIDE_KEY)
 

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -81,8 +81,6 @@ class TGISConnection:
 
     HOSTNAME_KEY = "hostname"
     HOSTNAME_TEMPLATE_MODEL_ID = "model_id"
-    NAMESPACE_KEY = "namespace"
-    HOSTNAME_TEMPLATE_NAMESPACE = "namespace"
     CA_CERT_FILE_KEY = "ca_cert_file"
     CLIENT_CERT_FILE_KEY = "client_cert_file"
     CLIENT_KEY_FILE_KEY = "client_key_file"
@@ -99,20 +97,13 @@ class TGISConnection:
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:
             assert isinstance(hostname, str)
-            namespace = config.get(cls.NAMESPACE_KEY)
 
             hostname = hostname.format_map(
                 {
                     cls.HOSTNAME_TEMPLATE_MODEL_ID: model_id,
-                    cls.HOSTNAME_TEMPLATE_NAMESPACE: namespace,
                 }
             )
-            log.debug(
-                "Resolved hostname [%s] for model %s in namespace %s",
-                hostname,
-                model_id,
-                namespace,
-            )
+            log.debug("Resolved hostname [%s] for model %s", hostname, model_id)
 
             tls_hostname_override = config.get(cls.TLS_HN_OVERRIDE_KEY)
             lb_policy = config.get(cls.LB_POLICY_KEY) or None

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -81,6 +81,7 @@ class TGISConnection:
 
     HOSTNAME_KEY = "hostname"
     HOSTNAME_TEMPLATE_MODEL_ID = "model_id"
+    # TODO: Add key for namespace here
     CA_CERT_FILE_KEY = "ca_cert_file"
     CLIENT_CERT_FILE_KEY = "client_cert_file"
     CLIENT_KEY_FILE_KEY = "client_key_file"
@@ -94,6 +95,7 @@ class TGISConnection:
         """Create an instance from a connection template and a model_id"""
         hostname = config.get(cls.HOSTNAME_KEY)
         if hostname:
+            # TODO: Namespace needs to be populated here as well into the hostname template
             hostname = hostname.format(
                 **{
                     cls.HOSTNAME_TEMPLATE_MODEL_ID: model_id,

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -32,7 +32,6 @@ import caikit
 # Local
 from caikit_tgis_backend import TGISBackend
 from caikit_tgis_backend.protobufs import generation_pb2
-from caikit_tgis_backend.tgis_connection import TGISConnection
 from tests.tgis_mock import (
     TGISMock,
     tgis_mock_insecure,
@@ -679,52 +678,6 @@ def test_tgis_backend_config_load_prompt_artifacts():
             # Make sure unknown model raises
             with pytest.raises(ValueError):
                 tgis_be.load_prompt_artifacts("buz", prompt_id1, source_files[0])
-
-
-def test_tgis_backend_register_model_connection():
-    """Test that register_model_connection correctly adds a TGISConnection to the _model_connections dictionary"""
-    tgis_be = TGISBackend(
-        {
-            "remote_models": {
-                "foo": {"hostname": "foo:123"},
-                "bar": {"hostname": "bar:123"},
-            },
-        }
-    )
-
-    new_model = {
-        "base_model_name": "newmodel_id1",
-        "connection_config": {
-            "hostname": "{model_id}.{namespace}.mycluster",
-            "namespace": "byom-1",
-            "grpc_lb_policy_name": "something",
-        },
-    }
-
-    # Assert new model is not in backend
-    assert new_model["base_model_name"] not in tgis_be._remote_models_cfg
-    assert new_model["base_model_name"] not in tgis_be._model_connections
-
-    # Register model
-    tgis_be.register_model_connection(
-        new_model["base_model_name"], new_model["connection_config"]
-    )
-    assert new_model["base_model_name"] in tgis_be._remote_models_cfg
-    assert new_model["base_model_name"] in tgis_be._model_connections
-    assert isinstance(
-        tgis_be._model_connections[new_model["base_model_name"]], TGISConnection
-    )
-    assert (
-        tgis_be._model_connections[new_model["base_model_name"]].hostname
-        == "newmodel_id1.byom-1.mycluster"
-    )
-
-    # Confirm get_connection works
-    conn = tgis_be.get_connection(new_model["base_model_name"], create=False)
-    assert isinstance(conn, TGISConnection)
-    assert conn.hostname == "newmodel_id1.byom-1.mycluster"
-    assert conn.model_id == new_model["base_model_name"]
-    assert conn.lb_policy == new_model["connection_config"]["grpc_lb_policy_name"]
 
 
 ## Failure Tests ###############################################################

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -16,6 +16,7 @@ Unit tests for TGIS backend
 """
 
 # Standard
+from copy import deepcopy
 from dataclasses import asdict
 from typing import Any, Dict, Optional
 from unittest import mock
@@ -736,6 +737,7 @@ def test_tgis_backend_register_model_connection(
     # Assert new model is not in backend
     assert model_id not in tgis_be._remote_models_cfg
     assert model_id not in tgis_be._model_connections
+    backup_base_cfg = deepcopy(tgis_be._base_connection_cfg)
 
     # Register model
     tgis_be.register_model_connection(model_id, conn_cfg, fill_with_defaults=fill)
@@ -764,6 +766,9 @@ def test_tgis_backend_register_model_connection(
         for k, v in asdict(tgis_be._model_connections[model_id]).items()
         if v is not None
     } == expected_conn_cfg
+
+    # Confirm that the source _base_connection_cfg wasn't mutated
+    assert tgis_be._base_connection_cfg == backup_base_cfg
 
 
 ## Failure Tests ###############################################################

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -32,6 +32,7 @@ import caikit
 # Local
 from caikit_tgis_backend import TGISBackend
 from caikit_tgis_backend.protobufs import generation_pb2
+from caikit_tgis_backend.tgis_connection import TGISConnection
 from tests.tgis_mock import (
     TGISMock,
     tgis_mock_insecure,
@@ -575,7 +576,6 @@ def test_tgis_backend_config_load_prompt_artifacts():
     """Make sure that loading prompt artifacts behaves as expected"""
     with tempfile.TemporaryDirectory() as source_dir:
         with tempfile.TemporaryDirectory() as prompt_dir:
-
             # Make some source files
             source_fnames = ["prompt1.pt", "prompt2.pt"]
             source_files = [os.path.join(source_dir, fname) for fname in source_fnames]
@@ -679,6 +679,52 @@ def test_tgis_backend_config_load_prompt_artifacts():
             # Make sure unknown model raises
             with pytest.raises(ValueError):
                 tgis_be.load_prompt_artifacts("buz", prompt_id1, source_files[0])
+
+
+def test_tgis_backend_register_model_connection():
+    """Test that register_model_connection correctly adds a TGISConnection to the _model_connections dictionary"""
+    tgis_be = TGISBackend(
+        {
+            "remote_models": {
+                "foo": {"hostname": "foo:123"},
+                "bar": {"hostname": "bar:123"},
+            },
+        }
+    )
+
+    new_model = {
+        "base_model_name": "newmodel_id1",
+        "connection_config": {
+            "hostname": "{model_id}.{namespace}.mycluster",
+            "namespace": "byom-1",
+            "grpc_lb_policy_name": "something",
+        },
+    }
+
+    # Assert new model is not in backend
+    assert new_model["base_model_name"] not in tgis_be._remote_models_cfg
+    assert new_model["base_model_name"] not in tgis_be._model_connections
+
+    # Register model
+    tgis_be.register_model_connection(
+        new_model["base_model_name"], new_model["connection_config"]
+    )
+    assert new_model["base_model_name"] in tgis_be._remote_models_cfg
+    assert new_model["base_model_name"] in tgis_be._model_connections
+    assert isinstance(
+        tgis_be._model_connections[new_model["base_model_name"]], TGISConnection
+    )
+    assert (
+        tgis_be._model_connections[new_model["base_model_name"]].hostname
+        == "newmodel_id1.byom-1.mycluster"
+    )
+
+    # Confirm get_connection works
+    conn = tgis_be.get_connection(new_model["base_model_name"], create=False)
+    assert isinstance(conn, TGISConnection)
+    assert conn.hostname == "newmodel_id1.byom-1.mycluster"
+    assert conn.model_id == new_model["base_model_name"]
+    assert conn.lb_policy == new_model["connection_config"]["grpc_lb_policy_name"]
 
 
 ## Failure Tests ###############################################################

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -33,6 +33,10 @@ import caikit
 from caikit_tgis_backend import TGISBackend
 from caikit_tgis_backend.protobufs import generation_pb2
 from caikit_tgis_backend.tgis_connection import TGISConnection
+from tests.tgis_mock import tgis_mock_insecure  # noqa
+from tests.tgis_mock import tgis_mock_insecure_health_delay  # noqa
+from tests.tgis_mock import tgis_mock_mtls  # noqa
+from tests.tgis_mock import tgis_mock_tls  # noqa
 from tests.tgis_mock import TGISMock
 
 ## Helpers #####################################################################

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -79,30 +79,6 @@ def test_happy_path_template():
     )
 
 
-def test_happy_path_template_with_namespace():
-    template_model_id = "{{{}}}".format(TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID)
-    template_namespace = "{{{}}}".format(TGISConnection.HOSTNAME_TEMPLATE_NAMESPACE)
-    template = (
-        f"{template_model_id}-predictor.'{template_namespace}'.svc.cluster.local:8033"
-    )
-
-    model_id = "some/model"
-    namespace = "byom4"
-    conn = TGISConnection.from_config(
-        model_id,
-        {
-            TGISConnection.HOSTNAME_KEY: template,
-            TGISConnection.NAMESPACE_KEY: namespace,
-        },
-    )
-    assert conn.hostname == template.format_map(
-        {
-            TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID: model_id,
-            TGISConnection.HOSTNAME_TEMPLATE_NAMESPACE: namespace,
-        }
-    )
-
-
 def test_happy_path_tls(temp_ca_cert):
     conn = TGISConnection.from_config(
         "",

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the TGISConnection class
 """
+
 # Standard
 from contextlib import contextmanager
 from pathlib import Path
@@ -75,6 +76,30 @@ def test_happy_path_template():
     )
     assert conn.hostname == template.format(
         **{TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID: model_id}
+    )
+
+
+def test_happy_path_template_with_namespace():
+    template_model_id = "{{{}}}".format(TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID)
+    template_namespace = "{{{}}}".format(TGISConnection.HOSTNAME_TEMPLATE_NAMESPACE)
+    template = (
+        f"{template_model_id}-predictor.'{template_namespace}'.svc.cluster.local:8033"
+    )
+
+    model_id = "some/model"
+    namespace = "byom4"
+    conn = TGISConnection.from_config(
+        model_id,
+        {
+            TGISConnection.HOSTNAME_KEY: template,
+            TGISConnection.NAMESPACE_KEY: namespace,
+        },
+    )
+    assert conn.hostname == template.format_map(
+        {
+            TGISConnection.HOSTNAME_TEMPLATE_MODEL_ID: model_id,
+            TGISConnection.HOSTNAME_TEMPLATE_NAMESPACE: namespace,
+        }
     )
 
 

--- a/tests/test_tgis_connection.py
+++ b/tests/test_tgis_connection.py
@@ -28,7 +28,7 @@ import tls_test_tools
 
 # Local
 from caikit_tgis_backend.tgis_connection import TGISConnection
-from tests.tgis_mock import tgis_mock_insecure
+from tests.tgis_mock import tgis_mock_insecure  # noqa
 
 
 @contextmanager


### PR DESCRIPTION
Added `TGISBackend.register_model_connection()` to allow for registering a new `TGISConnection` model connection with either the default connection, a custom provided connection, or a mixture where the custom provided connection is enhanced by populating the missing settings with those from the default connection.

If the connection already exists, it does nothing.


Additionally the following refactoring was done:
- Refactor common model connection testing code into `TGISBackend._test_connection()`
- Refactor common state update logic into `TGISBackend._safely_update_state()` to ensure thread safe updates to the `_model_connections` and `_remote_models_cfg` dictionaries.