### PR TITLE
Handle runtime context

### DIFF
--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -21,10 +21,21 @@ from typing import Any, Dict, Optional
 # Third Party
 import grpc
 
+# Since fastapi is optional in caikit, it may not be available
+try:
+    # Third Party
+    import fastapi
+
+    HAVE_FASTAPI = True
+except ImportError:
+    HAVE_FASTAPI = False
+    fastapi = None
+
 # First Party
 from caikit.core.exceptions import error_handler
 from caikit.core.module_backends.backend_types import register_backend_type
 from caikit.core.module_backends.base import BackendBase
+from caikit.interfaces.runtime.data_model import RuntimeServerContextType
 import alog
 
 # Local
@@ -53,6 +64,10 @@ class TGISBackend(BackendBase):
 
     TGIS_LOCAL_GRPC_PORT = 50055
     TGIS_LOCAL_HTTP_PORT = 3000
+
+    # HTTP Header / gRPC Metadata key used to identify a route override in an
+    # inbound request context
+    ROUTE_INFO_HEADER_KEY = "x-route-info"
 
     ## Backend Interface ##
 
@@ -311,6 +326,34 @@ class TGISBackend(BackendBase):
         return not self.local_tgis or (
             self._managed_tgis is not None and self._managed_tgis.is_ready()
         )
+
+    @classmethod
+    def get_route_info(
+        cls,
+        context: Optional[RuntimeServerContextType],
+    ) -> Optional[str]:
+        """Get the string value of the x-route-info header/metadata if present
+
+        Args:
+            context (Optional[RuntimeServerContextType]): The grpc or fastapi
+                request context
+
+        Returns:
+            route_info (Optional[str]): The header/metadata value if present,
+                otherwise None
+        """
+        if context is None:
+            return context
+        if isinstance(context, grpc.ServicerContext):
+            return dict(context.invocation_metadata()).get(cls.ROUTE_INFO_HEADER_KEY)
+        if HAVE_FASTAPI and isinstance(context, fastapi.Request):
+            return context.headers.get(cls.ROUTE_INFO_HEADER_KEY)
+        error.log_raise(
+            "<TGB92615097E>",
+            TypeError(f"context is of an unsupported type: {type(context)}"),
+        )
+
+    ## Implementation Details ##
 
     def _test_connection(
         self, model_conn: Optional[TGISConnection], timeout: Optional[float] = None

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -179,6 +179,24 @@ class TGISBackend(BackendBase):
             log.debug("Unloading model %s on stop", model_id)
             self.unload_model(model_id)
 
+    def handle_runtime_context(
+        self,
+        model_id: str,
+        runtime_context: RuntimeServerContextType,
+    ):
+        """Handle the runtime context for a request for the given model"""
+        if route_info := self.get_route_info(runtime_context):
+            log.debug(
+                "<TGB10705560D> Registering remote model connection with context "
+                "override: 'hostname: %s'",
+                route_info,
+            )
+            self.register_model_connection(
+                model_id,
+                {"hostname": route_info},
+                fill_with_defaults=True,
+            )
+
     ## Backend user interface ##
 
     def get_connection(

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -102,7 +102,7 @@ class TestServicerContext:
     A dummy class for mimicking ServicerContext invocation metadata storage.
     """
 
-    def __init__(self, metadata: dict[str, Union[str, bytes]]):
+    def __init__(self, metadata: Dict[str, Union[str, bytes]]):
         self.metadata = metadata
 
     def invocation_metadata(self):

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -947,7 +947,7 @@ def test_tgis_backend_conn_testing_enabled(tgis_mock_insecure):
             TestServicerContext({"route-info": "sometext"}),
             None,
         ),
-        ("should raise ValueError", None),
+        ("should raise TypeError", None),
         (None, None),
         # Uncertain how to create a grpc.ServicerContext object
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     grpcio-tools>=1.35.0,<2.0
     wheel>=0.38.4
     Flask>=2.2.3,<3
+    fastapi[all]>=0.100,<1
 passenv =
     LOG_LEVEL
     LOG_FILTERS


### PR DESCRIPTION
## Description

This PR implements `TGISBackend.handle_runtime_context`. This is a new API on `BackendBase` introduced in [caikit](https://github.com/caikit/caikit/pull/735) in order to allow `caikit.runtime` to proactively notify configured backends of request contexts.

**NOTE**: This PR does _not_ bump the minimum version in `caikit` because implementing this function does not require that there be a base implementation. If used with an older version of `caikit`, it simply won't get called.