### PR TITLE
Bug fix: Make get_route_info() case insensitive

### DIFF
--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -16,7 +16,7 @@
 # Standard
 from copy import deepcopy
 from threading import Lock
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 # Third Party
 import grpc
@@ -431,7 +431,7 @@ class TGISBackend(BackendBase):
         If no matching header was found return None.
         """
         # https://github.com/encode/starlette/blob/5ed55c441126687106109a3f5e051176f88cd3e6/starlette/datastructures.py#L543
-        items: list[tuple[str, str]] = request.headers.items()
+        items: list[Tuple[str, str]] = request.headers.items()
         get_header_key = key.lower()
 
         for header_key, header_value in items:
@@ -440,7 +440,7 @@ class TGISBackend(BackendBase):
 
     @classmethod
     def _request_metadata_get(
-        cls, metadata: tuple[str, Union[str, bytes]], key: str
+        cls, metadata: Tuple[str, Union[str, bytes]], key: str
     ) -> Optional[str]:
         """
         Returns the first matching value for the metadata key (case insensitive).

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -927,29 +927,79 @@ def test_tgis_backend_conn_testing_enabled(tgis_mock_insecure):
                 {
                     "type": "http",
                     "headers": [
-                        (TGISBackend.ROUTE_INFO_HEADER_KEY.encode(), b"sometext")
+                        (
+                            TGISBackend.ROUTE_INFO_HEADER_KEY.encode("latin-1"),
+                            "http exact".encode("latin-1"),
+                        )
                     ],
                 }
             ),
-            "sometext",
+            "http exact",
         ),
         (
             fastapi.Request(
-                {"type": "http", "headers": [(b"route-info", b"sometext")]}
+                {
+                    "type": "http",
+                    "headers": [
+                        (
+                            TGISBackend.ROUTE_INFO_HEADER_KEY.upper().encode("latin-1"),
+                            "http upper-case".encode("latin-1"),
+                        )
+                    ],
+                }
+            ),
+            "http upper-case",
+        ),
+        (
+            fastapi.Request(
+                {
+                    "type": "http",
+                    "headers": [
+                        (
+                            TGISBackend.ROUTE_INFO_HEADER_KEY.title().encode("latin-1"),
+                            "http title-case".encode("latin-1"),
+                        )
+                    ],
+                }
+            ),
+            "http title-case",
+        ),
+        (
+            fastapi.Request(
+                {
+                    "type": "http",
+                    "headers": [
+                        (
+                            "route-info".encode("latin-1"),
+                            "http not-found".encode("latin-1"),
+                        )
+                    ],
+                }
             ),
             None,
         ),
         (
-            TestServicerContext({TGISBackend.ROUTE_INFO_HEADER_KEY: "sometext"}),
-            "sometext",
+            TestServicerContext({TGISBackend.ROUTE_INFO_HEADER_KEY: "grpc exact"}),
+            "grpc exact",
         ),
         (
-            TestServicerContext({"route-info": "sometext"}),
+            TestServicerContext(
+                {TGISBackend.ROUTE_INFO_HEADER_KEY.upper(): "grpc upper-case"}
+            ),
+            "grpc upper-case",
+        ),
+        (
+            TestServicerContext(
+                {TGISBackend.ROUTE_INFO_HEADER_KEY.title(): "grpc title-case"}
+            ),
+            "grpc title-case",
+        ),
+        (
+            TestServicerContext({"route-info": "grpc not found"}),
             None,
         ),
         ("should raise TypeError", None),
         (None, None),
-        # Uncertain how to create a grpc.ServicerContext object
     ],
 )
 def test_get_route_info(context, route_info: Optional[str]):
@@ -969,9 +1019,7 @@ def test_handle_runtime_context_with_route_info():
     context = fastapi.Request(
         {
             "type": "http",
-            "headers": [
-                (TGISBackend.ROUTE_INFO_HEADER_KEY.encode(), route_info.encode("utf-8"))
-            ],
+            "headers": [(TGISBackend.ROUTE_INFO_HEADER_KEY, route_info)],
         }
     )
 

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -1062,7 +1062,12 @@ def test_handle_runtime_context_with_route_info():
     context = fastapi.Request(
         {
             "type": "http",
-            "headers": [(TGISBackend.ROUTE_INFO_HEADER_KEY, route_info)],
+            "headers": [
+                (
+                    TGISBackend.ROUTE_INFO_HEADER_KEY.encode("latin-1"),
+                    route_info.encode("latin-1"),
+                )
+            ],
         }
     )
 

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -1041,13 +1041,13 @@ def test_tgis_backend_conn_testing_enabled(tgis_mock_insecure):
             TestServicerContext({"route-info": "grpc not found"}),
             None,
         ),
-        ("should raise TypeError", None),
+        ("should raise TypeError", TypeError()),
         (None, None),
     ],
 )
-def test_get_route_info(context, route_info: Optional[str]):
-    if not isinstance(context, (fastapi.Request, grpc.ServicerContext, type(None))):
-        with pytest.raises(TypeError):
+def test_get_route_info(context, route_info: Union[str, None, Exception]):
+    if isinstance(route_info, Exception):
+        with pytest.raises(type(route_info)):
             TGISBackend.get_route_info(context)
     else:
         actual_route_info = TGISBackend.get_route_info(context)

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -18,7 +18,7 @@ Unit tests for TGIS backend
 # Standard
 from copy import deepcopy
 from dataclasses import asdict
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Sequence, Union
 from unittest import mock
 import os
 import tempfile
@@ -97,7 +97,7 @@ def mock_tgis_fixture():
     mock_tgis.stop()
 
 
-class TestServicerContext:
+class TestServicerContext(grpc.ServicerContext):
     """
     A dummy class for mimicking ServicerContext invocation metadata storage.
     """
@@ -105,8 +105,51 @@ class TestServicerContext:
     def __init__(self, metadata: Dict[str, Union[str, bytes]]):
         self.metadata = metadata
 
-    def invocation_metadata(self):
+    def invocation_metadata(self) -> Sequence[tuple[str, Union[str, bytes]]]:
+        # https://grpc.github.io/grpc/python/glossary.html#term-metadata
         return list(self.metadata.items())
+
+    def is_active(self):
+        raise NotImplementedError
+
+    def time_remaining(self):
+        raise NotImplementedError
+
+    def cancel(self):
+        raise NotImplementedError
+
+    def add_callback(self, callback):
+        raise NotImplementedError
+
+    def peer(self):
+        raise NotImplementedError
+
+    def peer_identities(self):
+        raise NotImplementedError
+
+    def peer_identity_key(self):
+        raise NotImplementedError
+
+    def auth_context(self):
+        raise NotImplementedError
+
+    def send_initial_metadata(self, initial_metadata):
+        raise NotImplementedError
+
+    def set_trailing_metadata(self, trailing_metadata):
+        raise NotImplementedError
+
+    def abort(self, code, details):
+        raise NotImplementedError
+
+    def abort_with_status(self, status):
+        raise NotImplementedError
+
+    def set_code(self, code):
+        raise NotImplementedError
+
+    def set_details(self, details):
+        raise NotImplementedError
 
 
 ## Conn Config #################################################################

--- a/tests/test_tgis_backend.py
+++ b/tests/test_tgis_backend.py
@@ -18,7 +18,7 @@ Unit tests for TGIS backend
 # Standard
 from copy import deepcopy
 from dataclasses import asdict
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 from unittest import mock
 import os
 import tempfile
@@ -105,7 +105,7 @@ class TestServicerContext(grpc.ServicerContext):
     def __init__(self, metadata: Dict[str, Union[str, bytes]]):
         self.metadata = metadata
 
-    def invocation_metadata(self) -> Sequence[tuple[str, Union[str, bytes]]]:
+    def invocation_metadata(self) -> Sequence[Tuple[str, Union[str, bytes]]]:
         # https://grpc.github.io/grpc/python/glossary.html#term-metadata
         return list(self.metadata.items())
 


### PR DESCRIPTION
This PR makes `TGISBackend.get_route_info()`'s operation case insensitive.

Both [gRPC](https://grpc.github.io/grpc/python/glossary.html#term-metadatum) and [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) defines their metadatum/headers as case insensitive. This requires any lookup of keys to be done in a case insensitive manner.

Additionally fixed the `test_get_route_info` test:
- The expected to raise error case was incorrectly being identified
- updated `TestServicerContext` to inherit from `grpc.ServicesContext`. This was required because `TGISBackend.get_route_info()` test if the servicer context is of `grpc.ServicerContext` before attempting to access the metadata.
- Set encoding to `latin-1` as per http spec and what starlette expects.

Note:
Depending on how the`fastapi.Request` object (actually a starlette.requests.Request object) is created, it might not instantiate its headers in a case insensitive manner. If the `starlette.datastructures.Headers` is created via the [`scope=` parameter ](https://github.com/encode/starlette/blob/5ed55c441126687106109a3f5e051176f88cd3e6/starlette/requests.py#L120-L123) the header keys still [remain case sensitive](https://github.com/encode/starlette/blob/5ed55c441126687106109a3f5e051176f88cd3e6/starlette/datastructures.py#L528-L531). This is why `Headers.get()` is not reliable and a custom `TGISBackend._request_header_get()` was necessary.